### PR TITLE
Progress bars - Initial implementation

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -27,6 +27,7 @@ import Demo.Snackbar
 import Demo.Badges
 import Demo.Elevation
 import Demo.Toggles
+import Demo.ProgressBar
 --import Demo.Template
 
 
@@ -70,6 +71,7 @@ type alias Model =
   , textfields : Demo.Textfields.Model
   , toggles : Demo.Toggles.Model
   , snackbar : Demo.Snackbar.Model
+  , progressbar : Demo.ProgressBar.Model
   --, template : Demo.Template.Model
   , selectedTab : Int
   }
@@ -85,6 +87,7 @@ model =
   , textfields = Demo.Textfields.model
   , toggles = Demo.Toggles.model
   , snackbar = Demo.Snackbar.model
+  , progressbar = Demo.ProgressBar.model
   --, template = Demo.Template.model
   , selectedTab = 0
   }
@@ -109,6 +112,7 @@ type Msg
   | TextfieldMsg Demo.Textfields.Msg
   | SnackbarMsg Demo.Snackbar.Msg
   | TogglesMsg Demo.Toggles.Msg
+  | ProgressBarMsg Demo.ProgressBar.Msg
   --| TemplateMsg Demo.Template.Msg
 
 
@@ -165,6 +169,8 @@ update action model =
 --
     TogglesMsg    a -> lift .toggles   (\m x->{m|toggles    =x}) TogglesMsg Demo.Toggles.update   a model
 --
+    ProgressBarMsg  a -> lift  .progressbar   (\m x->{m|progressbar  =x}) ProgressBarMsg Demo.ProgressBar.update   a model
+--
     --TemplateMsg  a -> lift  .template   (\m x->{m|template  =x}) TemplateMsg Demo.Template.update   a model
 
         
@@ -215,6 +221,7 @@ tabs =
   , ("Snackbar", "snackbar", .snackbar >> Demo.Snackbar.view >> App.map SnackbarMsg)
   , ("Textfields", "textfields", .textfields >> Demo.Textfields.view >> App.map TextfieldMsg)
   , ("Toggles", "toggles", .toggles >> Demo.Toggles.view >> App.map TogglesMsg)
+  , ("ProgressBar", "progressbar", .progressbar >> Demo.ProgressBar.view >> App.map ProgressBarMsg)
   --, ("Template", "template", .template >> Demo.Template.view >> App.map TemplateMsg)
   --    Demo.Template.view (Signal.forwardTo addr TemplateMsg) model.template)
   ]

--- a/demo/Demo/ProgressBar.elm
+++ b/demo/Demo/ProgressBar.elm
@@ -79,24 +79,34 @@ view model  =
             ]
         ])
     ]
-  --|> Page.body2 "TEMPLATE" srcUrl intro references
 
 
 intro : Html m
 intro =
-  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
-> ...
+  Page.fromMDL "https://getmdl.io/components/index.html#loading-section/progress" """
+> The Material Design Lite (MDL) progress component is a visual indicator of
+> background activity in a web page or application. A progress indicator
+> consists of a (typically) horizontal bar containing some animation that
+> conveys a sense of motion. While some progress devices indicate an approximate
+> or specific percentage of completion, the MDL progress component simply
+> communicates the fact that an activity is ongoing and is not yet complete.
+
+> Progress indicators are an established but non-standardized feature in user
+> interfaces, and provide users with a visual clue to an application's status.
+> Their design and use is therefore an important factor in the overall user
+> experience. See the progress component's Material Design specifications page for
+> details.
 """
 
 
 srcUrl : String
 srcUrl =
-  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/ProgressBar.elm"
 
 
 references : List (String, String)
 references =
-  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
-  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-ProgressBar"
+  , Page.mds "https://www.google.com/design/spec/components/progress-activity.html"
+  , Page.mdl "https://getmdl.io/components/index.html#loading-section/progress"
   ]

--- a/demo/Demo/ProgressBar.elm
+++ b/demo/Demo/ProgressBar.elm
@@ -1,0 +1,102 @@
+module Demo.ProgressBar exposing (..)
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+
+import Material.ProgressBar as ProgressBar
+import Material
+
+import Material.Grid as Grid
+import Demo.Page as Page
+
+
+
+-- MODEL
+
+
+type alias Mdl =
+  Material.Model
+
+
+type alias Model =
+  { mdl : Material.Model
+  }
+
+
+model : Model
+model =
+  { mdl = Material.model
+  }
+
+
+-- ACTION, UPDATE
+
+
+type Msg
+  = TemplateMsg
+  | Mdl Material.Msg
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+    TemplateMsg ->
+      (model, Cmd.none)
+
+    Mdl action' ->
+      Material.update Mdl action' model
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model  =
+  Page.body2 "ProgressBar" srcUrl intro references
+    [
+     (Grid.grid []
+        [ Grid.cell
+            [ Grid.size Grid.All 4]
+            [ ProgressBar.render Mdl [0] model.mdl
+                [ProgressBar.progress 35]
+                []
+            , p [] [text "Default progress bar"]
+            ]
+        , Grid.cell
+            [ Grid.size Grid.All 4]
+            [ ProgressBar.render Mdl [1] model.mdl
+                [ProgressBar.indeterminate] []
+            , p [] [text "Indeterminate"]
+            ]
+
+        , Grid.cell
+            [ Grid.size Grid.All 4]
+            [ ProgressBar.render Mdl [1] model.mdl
+                [ ProgressBar.buffer 78
+                , ProgressBar.progress 44]
+                []
+            , p [] [text "Buffering "]
+            ]
+        ])
+    ]
+  --|> Page.body2 "TEMPLATE" srcUrl intro references
+
+
+intro : Html m
+intro =
+  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
+> ...
+"""
+
+
+srcUrl : String
+srcUrl =
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+
+
+references : List (String, String)
+references =
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
+  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
+  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  ]

--- a/demo/Demo/ProgressBar.elm
+++ b/demo/Demo/ProgressBar.elm
@@ -5,9 +5,14 @@ import Html exposing (..)
 
 import Material.ProgressBar as ProgressBar
 import Material
+import Material.Options as Options
 
 import Material.Grid as Grid
 import Demo.Page as Page
+
+import Material.Helpers as Helpers
+
+import Material.Button as Button
 
 
 
@@ -20,12 +25,16 @@ type alias Mdl =
 
 type alias Model =
   { mdl : Material.Model
+  , started : Bool
+  , currentProgress : Float
   }
 
 
 model : Model
 model =
   { mdl = Material.model
+  , started = False
+  , currentProgress = 0
   }
 
 
@@ -33,15 +42,38 @@ model =
 
 
 type Msg
-  = TemplateMsg
+  = Tick
   | Mdl Material.Msg
+  | Start
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
-    TemplateMsg ->
-      (model, Cmd.none)
+      -- 'Simulate' a process that takes some time
+    Tick ->
+      let
+        nextProgress = model.currentProgress + 1
+        progress = if nextProgress > 100 then
+                     0
+                   else
+                     nextProgress
+
+        finishedLoading = nextProgress > 100
+
+        command = if not finishedLoading then
+                    Helpers.delay 100 Tick
+                  else
+                    Cmd.none
+      in
+        ({ model | currentProgress = progress
+         , started = not finishedLoading }, command)
+
+    Start ->
+      if model.started then
+        (model, Cmd.none)
+      else
+        ({ model | started = True}, Helpers.delay 200 Tick)
 
     Mdl action' ->
       Material.update Mdl action' model
@@ -52,7 +84,7 @@ update action model =
 
 view : Model -> Html Msg
 view model  =
-  Page.body2 "ProgressBar" srcUrl intro references
+  Page.body2 "Progress bars" srcUrl intro references
     [
      (Grid.grid []
         [ Grid.cell
@@ -71,11 +103,28 @@ view model  =
 
         , Grid.cell
             [ Grid.size Grid.All 4]
-            [ ProgressBar.render Mdl [1] model.mdl
+            [ ProgressBar.render Mdl [2] model.mdl
                 [ ProgressBar.buffer 78
                 , ProgressBar.progress 44]
                 []
             , p [] [text "Buffering "]
+            ]
+
+        , Grid.cell
+            [ Grid.size Grid.All 4]
+            [ ProgressBar.render Mdl [3] model.mdl
+                [ ProgressBar.progress model.currentProgress ]
+                []
+            , p [] [text "Loading bar with progress update"]
+            , div []
+              [ Button.render Mdl [4] model.mdl
+                  [ Button.raised
+                  , Button.colored
+                  , Button.ripple
+                  , if model.started then Button.disabled else Options.nop
+                  , Button.onClick (Start)]
+                  [text "Start loading"]
+              ]
             ]
         ])
     ]
@@ -90,12 +139,13 @@ intro =
 > conveys a sense of motion. While some progress devices indicate an approximate
 > or specific percentage of completion, the MDL progress component simply
 > communicates the fact that an activity is ongoing and is not yet complete.
-
+>
 > Progress indicators are an established but non-standardized feature in user
 > interfaces, and provide users with a visual clue to an application's status.
 > Their design and use is therefore an important factor in the overall user
 > experience. See the progress component's Material Design specifications page for
 > details.
+
 """
 
 

--- a/demo/Demo/ProgressBar.elm
+++ b/demo/Demo/ProgressBar.elm
@@ -89,32 +89,26 @@ view model  =
      (Grid.grid []
         [ Grid.cell
             [ Grid.size Grid.All 4]
-            [ ProgressBar.render Mdl [0] model.mdl
-                [ProgressBar.progress 35]
-                []
+            [ ProgressBar.view [ ProgressBar.progress 35 ]
             , p [] [text "Default progress bar"]
             ]
         , Grid.cell
             [ Grid.size Grid.All 4]
-            [ ProgressBar.render Mdl [1] model.mdl
-                [ProgressBar.indeterminate] []
+            [ ProgressBar.view [ ProgressBar.indeterminate ]
             , p [] [text "Indeterminate"]
             ]
 
         , Grid.cell
             [ Grid.size Grid.All 4]
-            [ ProgressBar.render Mdl [2] model.mdl
+            [ ProgressBar.view
                 [ ProgressBar.buffer 78
                 , ProgressBar.progress 44]
-                []
             , p [] [text "Buffering "]
             ]
 
         , Grid.cell
             [ Grid.size Grid.All 4]
-            [ ProgressBar.render Mdl [3] model.mdl
-                [ ProgressBar.progress model.currentProgress ]
-                []
+            [ ProgressBar.view [ ProgressBar.progress model.currentProgress ]
             , p [] [text "Loading bar with progress update"]
             , div []
               [ Button.render Mdl [4] model.mdl

--- a/elm-package.json
+++ b/elm-package.json
@@ -19,7 +19,8 @@
         "Material.Icon",
         "Material.Layout",
         "Material.Snackbar",
-        "Material.Textfield"
+        "Material.Textfield",
+        "Material.ProgressBar"
     ],
     "dependencies": {
         "debois/elm-dom": "1.2.0 <= v < 2.0.0",

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -172,6 +172,7 @@ import Material.Menu as Menu
 import Material.Snackbar as Snackbar
 import Material.Layout as Layout
 import Material.Toggles as Toggles
+import Material.ProgressBar as ProgressBar
 --import Material.Template as Template
 
 
@@ -186,6 +187,7 @@ type alias Model =
   , snackbar : Maybe (Snackbar.Model Int) 
   , layout : Layout.Model
   , toggles : Indexed Toggles.Model
+  , progressbar : Indexed ProgressBar.Model
 --  , template : Indexed Template.Model
   }
 
@@ -200,6 +202,7 @@ model =
   , snackbar = Nothing
   , layout = Layout.defaultModel
   , toggles = Dict.empty
+  , progressbar = Dict.empty
 --  , template = Dict.empty
   }
 

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -187,7 +187,6 @@ type alias Model =
   , snackbar : Maybe (Snackbar.Model Int) 
   , layout : Layout.Model
   , toggles : Indexed Toggles.Model
-  , progressbar : Indexed ProgressBar.Model
 --  , template : Indexed Template.Model
   }
 
@@ -202,7 +201,6 @@ model =
   , snackbar = Nothing
   , layout = Layout.defaultModel
   , toggles = Dict.empty
-  , progressbar = Dict.empty
 --  , template = Dict.empty
   }
 

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -172,7 +172,6 @@ import Material.Menu as Menu
 import Material.Snackbar as Snackbar
 import Material.Layout as Layout
 import Material.Toggles as Toggles
-import Material.ProgressBar as ProgressBar
 --import Material.Template as Template
 
 

--- a/src/Material/ProgressBar.elm
+++ b/src/Material/ProgressBar.elm
@@ -1,29 +1,45 @@
 module Material.ProgressBar exposing
-  ( Model, defaultModel, Msg, update, view
+  ( view
   , Property
-  , render
-  , default, indeterminate, buffering
+  , BarType(Default, Indeterminate)
+  , default, indeterminate
   , progress, buffer
   )
 
--- TEMPLATE. Copy this to a file for your component, then update.
+{-| From the [Material Design Lite documentation](https://getmdl.io/components/index.html#loading-section/progress):
 
-{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
+> The Material Design Lite (MDL) progress component is a visual indicator of
+> background activity in a web page or application. A progress indicator
+> consists of a (typically) horizontal bar containing some animation that
+> conveys a sense of motion. While some progress devices indicate an approximate
+> or specific percentage of completion, the MDL progress component simply
+> communicates the fact that an activity is ongoing and is not yet complete.
 
-> ...
+> Progress indicators are an established but non-standardized feature in user
+> interfaces, and provide users with a visual clue to an application's status.
+> Their design and use is therefore an important factor in the overall user
+> experience. See the progress component's Material Design specifications page for
+> details.
 
 See also the
-[Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
+[Material Design Specification](https://material.google.com/components/progress-activity.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/template)
+Refer to [this site](http://debois.github.io/elm-mdl#/progressbar)
 for a live demo.
 
-@docs Model, model, Msg, update
+# Options
+@docs Property
+
+# Render
 @docs view
 
-# Component support
+# Type
+@docs BarType
+@docs default, indeterminate
 
-@docs Container, Observer, Instance, instance, fwdTemplate
+# Appearence
+@docs progress, buffer
+
 -}
 
 
@@ -36,47 +52,18 @@ import Material.Options as Options exposing (Style, cs, nop)
 
 import Html.Attributes exposing (class, classList, style)
 
--- MODEL
-
-
-{-| Component model.
--}
-type alias Model =
-  {
-  }
-
-
-{-| Default component model constructor.
--}
-defaultModel : Model
-defaultModel =
-  {
-  }
-
-
--- ACTION, UPDATE
-
-
-{-| Component action.
--}
-type Msg
-  = NoOp
-
-
-{-| Component update.
--}
-update : Msg -> Model -> (Model, Cmd Msg)
-update action model =
-  case action of
-      NoOp -> (model, Cmd.none)
-
 
 -- PROPERTIES
 
+{-| The type of the progress bar.
+
+`Default` bars require the user to manually upgrade the the progress using `progress`.
+
+`Indeterminate` bars use CSS animations.
+-}
 type BarType
   = Default
   | Indeterminate
-  | Buffering
 
 
 type alias Config =
@@ -94,35 +81,49 @@ defaultConfig =
   }
 
 
+{-| Properties for Progress bar options.
+-}
 type alias Property m =
   Options.Property Config m
 
+-- Helper functions
 
-{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
--}
-
+clamp : number -> number -> number -> number
 clamp mn mx val =
   max (min mx val) 0
 
+clampSize : number -> number
 clampSize = clamp 0 100
 
+-- ATTRIBUTES
+
+{-| Set the type of the progress bar to default
+-}
 default : Property m
 default =
   Options.set (\config -> { config | bartype = Default })
 
+{-| Set the type of the progress bar to 'indeterminate'.
+
+Indeterminate progress bars show an animated indicator
+-}
 indeterminate : Property m
 indeterminate =
   Options.set (\config -> { config | bartype = Indeterminate })
 
-buffering : Property m
-buffering =
-  Options.set (\config -> { config | bartype = Buffering })
 
+{-| Sets the progress of the bar to the given value.
 
+TODO: Example
+-}
 progress : Float -> Property m
 progress amount =
   Options.set (\config -> { config | progress =  clampSize amount})
 
+{-| Sets the buffer of the bar to the given value.
+
+TODO: Example
+-}
 buffer : Float -> Property m
 buffer amount =
   Options.set (\config -> { config | buffer =  clampSize amount})
@@ -130,68 +131,44 @@ buffer amount =
 -- VIEW
 
 
-
-
 {-| Component view.
 -}
-view : (Msg -> m) -> Model -> List (Property m) -> List (Html m) -> Html m
-view lift model options elems =
+view : List (Property m) -> Html m
+view options =
   let
     summary = Options.collect defaultConfig options
     config = summary.config
 
   in
     Options.apply summary div
-      ([ cs "mdl-progress"
-       , cs "mdl-js-progress"
-       , cs "is-upgraded"
-       , if summary.config.bartype == Indeterminate then
-           cs "mdl-progress--indeterminate"
-         else
-           nop
-       ]
-        )
-        []
-        [ div [ classList
-                    [ ("progressbar", True)
-                    , ("bar", True)
-                    , ("bar1", True)
-                    ]
-              , style [("width", (toString (config.progress) ++ "%"))]
-              ] []
-        , div [ classList
-                    [ ("bufferbar", True)
-                    , ("bar", True)
-                    , ("bar2", True)
-                    ]
-              , style [("width", (toString (config.buffer) ++ "%"))]
-              ] []
-        , div [ classList
-                    [ ("auxbar", True)
-                    , ("bar", True)
-                    , ("bar3", True)
-                    ]
-              , style [("width", (toString (100 - config.buffer) ++ "%"))]
-              ] []
-        ]
-
-
--- COMPONENT
-
-type alias Container c =
-  { c | progressbar : Indexed Model }
-
-
-{-| Component render.
--}
-render
-  : (Parts.Msg (Container c) -> m)
-  -> Parts.Index
-  -> (Container c)
-  -> List (Property m)
-  -> List (Html m)
-  -> Html m
-render =
-  Parts.create view update .progressbar (\x y -> {y | progressbar=x}) defaultModel
-
-{- See src/Material/Layout.mdl for how to add subscriptions. -}
+      [ cs "mdl-progress"
+      , cs "mdl-js-progress"
+      , cs "is-upgraded"
+      , if summary.config.bartype == Indeterminate then
+          cs "mdl-progress--indeterminate"
+        else
+          nop
+      ]
+      []
+      [ div [ classList
+                  [ ("progressbar", True)
+                  , ("bar", True)
+                  , ("bar1", True)
+                  ]
+            , style [("width", (toString (config.progress) ++ "%"))]
+            ] []
+      , div [ classList
+                  [ ("bufferbar", True)
+                  , ("bar", True)
+                  , ("bar2", True)
+                  ]
+            , style [("width", (toString (config.buffer) ++ "%"))]
+            ] []
+      , div [ classList
+                  [ ("auxbar", True)
+                  , ("bar", True)
+                  , ("bar3", True)
+                  ]
+            , style [("width", (toString (100 - config.buffer) ++ "%"))]
+            ] []
+      ]

--- a/src/Material/ProgressBar.elm
+++ b/src/Material/ProgressBar.elm
@@ -97,7 +97,7 @@ clampSize = clamp 0 100
 
 -- ATTRIBUTES
 
-{-| Set the type of the progress bar to default
+{-| Set the type of the progress bar to 'default'.
 -}
 default : Property m
 default =
@@ -112,17 +112,13 @@ indeterminate =
   Options.set (\config -> { config | bartype = Indeterminate })
 
 
-{-| Sets the progress of the bar to the given value.
-
-TODO: Example
+{-| Set the current progress of the progressbar.
 -}
 progress : Float -> Property m
 progress amount =
   Options.set (\config -> { config | progress =  clampSize amount})
 
-{-| Sets the buffer of the bar to the given value.
-
-TODO: Example
+{-| Set the current progress of the buffer.
 -}
 buffer : Float -> Property m
 buffer amount =
@@ -131,7 +127,17 @@ buffer amount =
 -- VIEW
 
 
-{-| Component view.
+{-| View function for progress bars. Set the progress of the bar with `progress`,
+you can also set the buffer of the bar using `buffer`. You can also use an indeterminate
+progress bar by using `indeterminate`.
+
+For example:
+
+    import Material.ProgressBar as ProgressBar
+
+    progressBar : Html m
+    progressBar = ProgressBar.view [ ProgressBar.progress 35
+                                   , ProgressBar.buffer 85]
 -}
 view : List (Property m) -> Html m
 view options =

--- a/src/Material/ProgressBar.elm
+++ b/src/Material/ProgressBar.elm
@@ -43,12 +43,9 @@ for a live demo.
 -}
 
 
-import Platform.Cmd exposing (Cmd, none)
 import Html exposing (..)
 
-import Parts exposing (Indexed)
 import Material.Options as Options exposing (Style, cs, nop)
-
 
 import Html.Attributes exposing (class, classList, style)
 

--- a/src/Material/ProgressBar.elm
+++ b/src/Material/ProgressBar.elm
@@ -1,0 +1,197 @@
+module Material.ProgressBar exposing
+  ( Model, defaultModel, Msg, update, view
+  , Property
+  , render
+  , default, indeterminate, buffering
+  , progress, buffer
+  )
+
+-- TEMPLATE. Copy this to a file for your component, then update.
+
+{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
+
+> ...
+
+See also the
+[Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
+
+Refer to [this site](http://debois.github.io/elm-mdl#/template)
+for a live demo.
+
+@docs Model, model, Msg, update
+@docs view
+
+# Component support
+
+@docs Container, Observer, Instance, instance, fwdTemplate
+-}
+
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+
+import Parts exposing (Indexed)
+import Material.Options as Options exposing (Style, cs, nop)
+
+
+import Html.Attributes exposing (class, classList, style)
+
+-- MODEL
+
+
+{-| Component model.
+-}
+type alias Model =
+  {
+  }
+
+
+{-| Default component model constructor.
+-}
+defaultModel : Model
+defaultModel =
+  {
+  }
+
+
+-- ACTION, UPDATE
+
+
+{-| Component action.
+-}
+type Msg
+  = NoOp
+
+
+{-| Component update.
+-}
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+      NoOp -> (model, Cmd.none)
+
+
+-- PROPERTIES
+
+type BarType
+  = Default
+  | Indeterminate
+  | Buffering
+
+
+type alias Config =
+  { bartype : BarType
+  , progress : Float
+  , buffer : Float
+  }
+
+
+defaultConfig : Config
+defaultConfig =
+  { bartype = Default
+  , progress = 0
+  , buffer = 100
+  }
+
+
+type alias Property m =
+  Options.Property Config m
+
+
+{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
+-}
+
+clamp mn mx val =
+  max (min mx val) 0
+
+clampSize = clamp 0 100
+
+default : Property m
+default =
+  Options.set (\config -> { config | bartype = Default })
+
+indeterminate : Property m
+indeterminate =
+  Options.set (\config -> { config | bartype = Indeterminate })
+
+buffering : Property m
+buffering =
+  Options.set (\config -> { config | bartype = Buffering })
+
+
+progress : Float -> Property m
+progress amount =
+  Options.set (\config -> { config | progress =  clampSize amount})
+
+buffer : Float -> Property m
+buffer amount =
+  Options.set (\config -> { config | buffer =  clampSize amount})
+
+-- VIEW
+
+
+
+
+{-| Component view.
+-}
+view : (Msg -> m) -> Model -> List (Property m) -> List (Html m) -> Html m
+view lift model options elems =
+  let
+    summary = Options.collect defaultConfig options
+    config = summary.config
+
+  in
+    Options.apply summary div
+      ([ cs "mdl-progress"
+       , cs "mdl-js-progress"
+       , cs "is-upgraded"
+       , if summary.config.bartype == Indeterminate then
+           cs "mdl-progress--indeterminate"
+         else
+           nop
+       ]
+        )
+        []
+        [ div [ classList
+                    [ ("progressbar", True)
+                    , ("bar", True)
+                    , ("bar1", True)
+                    ]
+              , style [("width", (toString (config.progress) ++ "%"))]
+              ] []
+        , div [ classList
+                    [ ("bufferbar", True)
+                    , ("bar", True)
+                    , ("bar2", True)
+                    ]
+              , style [("width", (toString (config.buffer) ++ "%"))]
+              ] []
+        , div [ classList
+                    [ ("auxbar", True)
+                    , ("bar", True)
+                    , ("bar3", True)
+                    ]
+              , style [("width", (toString (100 - config.buffer) ++ "%"))]
+              ] []
+        ]
+
+
+-- COMPONENT
+
+type alias Container c =
+  { c | progressbar : Indexed Model }
+
+
+{-| Component render.
+-}
+render
+  : (Parts.Msg (Container c) -> m)
+  -> Parts.Index
+  -> (Container c)
+  -> List (Property m)
+  -> List (Html m)
+  -> Html m
+render =
+  Parts.create view update .progressbar (\x y -> {y | progressbar=x}) defaultModel
+
+{- See src/Material/Layout.mdl for how to add subscriptions. -}


### PR DESCRIPTION
Initial implementation of MDL progress bars. Currently the bars are stateless and the progress and buffer values are updated using the properties. The type of the bar can also be set to `indeterminate`, this will use the `mdl-progress--indeterminate` class to animate the bar.
 

Sample use: 
```    
import Material.ProgressBar as ProgressBar

progressBar : Html m
progressBar = ProgressBar.view [ ProgressBar.progress 35, ProgressBar.buffer 85]
```