### PR TITLE
Initial implementation of Tabs Component 

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -32,6 +32,7 @@ import Demo.Loading
 import Demo.Layout
 import Demo.Footer
 import Demo.Tooltip
+import Demo.Tabs
 --import Demo.Template
 
 
@@ -52,6 +53,7 @@ type alias Model =
   , loading : Demo.Loading.Model
   , footers : Demo.Footer.Model
   , tooltip : Demo.Tooltip.Model
+  , tabs : Demo.Tabs.Model
   --, template : Demo.Template.Model
   , selectedTab : Int
   , transparentHeader : Bool
@@ -72,6 +74,7 @@ model =
   , loading = Demo.Loading.model
   , footers = Demo.Footer.model
   , tooltip = Demo.Tooltip.model
+  , tabs = Demo.Tabs.model
   --, template = Demo.Template.model
   , selectedTab = 0
   , transparentHeader = False
@@ -96,6 +99,7 @@ type Msg
   | LoadingMsg Demo.Loading.Msg
   | FooterMsg Demo.Footer.Msg
   | TooltipMsg Demo.Tooltip.Msg
+  | TabMsg Demo.Tabs.Msg
   | ToggleHeader
   --| TemplateMsg Demo.Template.Msg
 
@@ -137,6 +141,8 @@ update action model =
     FooterMsg   a -> lift  .footers    (\m x->{m|footers   =x}) FooterMsg  Demo.Footer.update    a model
 
     TooltipMsg   a -> lift  .tooltip    (\m x->{m|tooltip   =x}) TooltipMsg  Demo.Tooltip.update    a model
+    TabMsg   a -> lift  .tabs    (\m x->{m|tabs   =x}) TabMsg  Demo.Tabs.update    a model
+
 
     --TemplateMsg  a -> lift  .template   (\m x->{m|template  =x}) TemplateMsg Demo.Template.update   a model
 
@@ -159,6 +165,7 @@ tabs =
   , ("Toggles", "toggles", .toggles >> Demo.Toggles.view >> App.map TogglesMsg)
   , ("Tables", "tables", .tables >> Demo.Tables.view >> App.map TablesMsg)
   , ("Tooltips", "tooltips", .tooltip >> Demo.Tooltip.view >> App.map TooltipMsg)
+  , ("Tabs", "tabs", .tabs >> Demo.Tabs.view >> App.map TabMsg)
   --, ("Template", "template", .template >> Demo.Template.view >> App.map TemplateMsg)
   ]
 

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -19,12 +19,14 @@ type alias Mdl =
 
 type alias Model =
   { mdl : Material.Model
+  , tab : Int
   }
 
 
 model : Model
 model =
   { mdl = Material.model
+  , tab = 0
   }
 
 
@@ -32,15 +34,18 @@ model =
 
 
 type Msg
-  = TemplateMsg
+  = SelectTab Int
   | Mdl Material.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
-    TemplateMsg ->
-      (model, Cmd.none)
+    SelectTab idx ->
+      let
+        _ = Debug.log "SELECTED" idx
+      in
+        ({ model | tab = idx }, Cmd.none)
 
     Mdl action' ->
       Material.update Mdl action' model
@@ -54,28 +59,38 @@ view model  =
   [ div
       []
       [ Tabs.render Mdl [0] model.mdl
-          [ Tabs.ripple ]
+          [ Tabs.ripple
+          , Tabs.onSelectTab SelectTab
+          , Tabs.selectTab model.tab
+          ]
           [ Tabs.tab
-             { panel = Tabs.panel [] [text "Tab One Content"]
-             , link = Tabs.link [] [text "Tab One"]
+             { link =
+                 Tabs.link
+                 []
+                 [text "Tab One"]
+
+             , panel =
+                 Tabs.panel
+                   []
+                   [text "Tab One Content"]
              }
           , Tabs.tab
-             { panel = Tabs.panel [] [text "Tab One Two"]
-             , link = Tabs.link [] [text "Tab Two"]
+             { link =
+                 Tabs.link
+                   []
+                   [text "Tab Two"]
+
+             , panel =
+                 Tabs.panel
+                   []
+                   [text "Tab One Two"]
              }
 
           ]
-          -- [ Tabs.tabBar []
-          --     [ Tabs.tabLink [Tabs.active] [text "Tab One"]
-          --     , Tabs.tabLink [] [text "Tab Two"]
-          --     ]
-          -- , Tabs.panel [Tabs.active]
-          --   [text "Panel 1"]
-
-          -- , Tabs.panel []
-          --   [text "Panel 2"]
-          -- ]
       ]
+  , div
+      [ style [("margin-top", "60px")]]
+      []
   ]
   |> Page.body2 "TEMPLATE" srcUrl intro references
 

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -61,8 +61,8 @@ view model  =
       , Tabs.selectTab model.tab
       ]
       [ Tabs.tab
-          { link =
-              Tabs.link
+          { label =
+              Tabs.label
               []
               [text "Example"]
 
@@ -81,8 +81,8 @@ view model  =
                            ]
 
                            [ Tabs.tab
-                           { link = Tabs.link [] [text "Tab One"]
-                           , panel = Tabs.panel [] [text "Tab One content"]
+                           { label = Tabs.label [] [text "Tab One"]
+                           , content = Tabs.content [] [text "Tab One content"]
                            }
                            ]
 
@@ -90,8 +90,8 @@ view model  =
               ]
           }
       , Tabs.tab
-        { link =
-            Tabs.link
+        { label =
+            Tabs.label
             []
             [text "About tabs"]
 

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -2,7 +2,7 @@ module Demo.Tabs exposing (..)
 
 import Platform.Cmd exposing (Cmd, none)
 import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html.Attributes as Html exposing (..)
 
 import Material.Tabs as Tabs
 import Material
@@ -52,67 +52,82 @@ update action model =
 
 -- VIEW
 
+aboutTab : Html Msg
+aboutTab =
+  Html.div
+    [ Html.style [("height", "430px")] ]
+    [ p []
+        [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
+        ]
+    , p []
+      [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
+    ]
+
+
+extraTab : Html Msg
+extraTab =
+  Html.div
+    [ Html.style [("height", "430px")] ]
+    [ p []
+        [ text "Tabs enable content organization at a high level, such as switching between views, data sets, or functional aspects of an app."
+        ]
+    , p []
+      [text "Use tabs to organize content at a high level, for example, to present different sections of a newspaper. Don’t use tabs for carousels or pagination of content. Those use cases involve viewing content, not navigating between groups of content."]
+    ]
+
+
+exampleTab : Html Msg
+exampleTab =
+  Code.code
+    """
+     import Material.Tabs as Tabs
+
+     tabs : Model -> Html Msg
+     tabs model =
+       Tabs.render Mdl [0] model.mdl
+           [ Tabs.ripple
+           , Tabs.onSelectTab SelectTab
+           , Tabs.selectTab model.tab
+           ]
+           [ Tabs.tab
+               { label = Tabs.label [] [text "Tab One"]
+               , content = Tabs.content [] [text "Tab One content"]
+               }
+
+           , Tabs.tab
+               { label = Tabs.label [] [text "Tab Two"]
+               , content = Tabs.content [] [text "Tab Two content"]
+               }
+           ]
+
+     """
+
 
 view : Model -> Html Msg
 view model  =
-  [ Tabs.render Mdl [0] model.mdl
-      [ Tabs.ripple
-      , Tabs.onSelectTab SelectTab
-      , Tabs.selectTab model.tab
-      ]
-      [ Tabs.tab
-          { label =
-              Tabs.label
-                []
-                [text "Example"]
+  let
+    _ = []
 
-          , content =
-              Tabs.content
-                []
-                [ Code.code """
-                            import Material.Tabs as Tabs
+    activeContent =
+      case model.tab of
+        0 -> exampleTab
+        1 -> aboutTab
+        _ -> extraTab
 
-                            tabs : Model -> Html Msg
-                            tabs model =
-                              Tabs.render Mdl [0] model.mdl
-                                  [ Tabs.ripple
-                                  , Tabs.onSelectTab SelectTab
-                                  , Tabs.selectTab model.tab
-                                  ]
-                                  [ Tabs.tab
-                                      { label = Tabs.label [] [text "Tab One"]
-                                      , content = Tabs.content [] [text "Tab One content"]
-                                      }
+  in
+    [ Tabs.render Mdl [0] model.mdl
+        [ Tabs.ripple
+        , Tabs.onSelectTab SelectTab
+        , Tabs.selectTab model.tab
+        ]
+        [ Tabs.label [] [text "Example"]
+        , Tabs.label [] [text "About tabs"]
+        , Tabs.label [] [text "Extra"]
+        ]
+        [ activeContent
+        ]
 
-                                  , Tabs.tab
-                                      { label = Tabs.label [] [text "Tab Two"]
-                                      , content = Tabs.content [] [text "Tab Two content"]
-                                      }
-                                  ]
-
-                            """
-                ]
-          }
-      , Tabs.tab
-        { label =
-            Tabs.label
-              []
-              [text "About tabs"]
-
-        , content =
-            Tabs.content
-              [ Options.css "padding-bottom" "85px" ]
-              [ p []
-                  [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
-                  ]
-              , p []
-                [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
-              ]
-        }
-
-
-      ]
-  ] |> Page.body2 "Tabs" srcUrl intro references
+    ] |> Page.body2 "Tabs" srcUrl intro references
 
 
 intro : Html m

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -6,6 +6,7 @@ import Html.Attributes exposing (..)
 
 import Material.Tabs as Tabs
 import Material
+import Material.Options as Options
 
 import Demo.Page as Page
 
@@ -67,23 +68,32 @@ view model  =
              { link =
                  Tabs.link
                  []
-                 [text "Tab One"]
+                 [text "About tabs"]
 
              , panel =
                  Tabs.panel
                    []
-                   [text "Tab One Content"]
+                   [ p []
+                       [ b [] [text "Tab"]
+                       , text " component is pretty cool."
+                       ]
+                   , p []
+                       [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
+                       ]
+                   ]
              }
+
           , Tabs.tab
              { link =
                  Tabs.link
                    []
-                   [text "Tab Two"]
+                   [text "Example"]
 
              , panel =
                  Tabs.panel
                    []
-                   [text "Tab One Two"]
+                   [
+                   ]
              }
 
           ]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -55,7 +55,7 @@ update action model =
 aboutTab : Html Msg
 aboutTab =
   Html.div
-    [ Html.style [("height", "430px")] ]
+    [ Html.style [("height", "380px")] ]
     [ p []
         [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
         ]
@@ -67,7 +67,7 @@ aboutTab =
 extraTab : Html Msg
 extraTab =
   Html.div
-    [ Html.style [("height", "430px")] ]
+    [ Html.style [("height", "380px")] ]
     [ p []
         [ text "Tabs enable content organization at a high level, such as switching between views, data sets, or functional aspects of an app."
         ]
@@ -89,15 +89,13 @@ exampleTab =
            , Tabs.onSelectTab SelectTab
            , Tabs.selectTab model.tab
            ]
-           [ Tabs.tab
-               { label = Tabs.label [] [text "Tab One"]
-               , content = Tabs.content [] [text "Tab One content"]
-               }
-
-           , Tabs.tab
-               { label = Tabs.label [] [text "Tab Two"]
-               , content = Tabs.content [] [text "Tab Two content"]
-               }
+           [ Tabs.label [] [text "Tab One"]
+           , Tabs.textLabel [] "Tab Two"
+           ]
+           [ case model.tab of
+               0 -> div [] [text "Content of tab one"]
+               1 -> div [] [text "Content of tab two"]
+               _ -> div [] []
            ]
 
      """
@@ -106,8 +104,6 @@ exampleTab =
 view : Model -> Html Msg
 view model  =
   let
-    _ = []
-
     activeContent =
       case model.tab of
         0 -> exampleTab
@@ -121,8 +117,8 @@ view model  =
         , Tabs.selectTab model.tab
         ]
         [ Tabs.label [] [text "Example"]
-        , Tabs.label [] [text "About tabs"]
-        , Tabs.label [] [text "Extra"]
+        , Tabs.label [] [text "About ", strong [] [text "Tabs"]]
+        , Tabs.textLabel [] "Extra"
         ]
         [ activeContent
         ]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -87,7 +87,7 @@ exampleTab =
        Tabs.render Mdl [0] model.mdl
            [ Tabs.ripple
            , Tabs.onSelectTab SelectTab
-           , Tabs.selectTab model.tab
+           , Tabs.activeTab model.tab
            ]
            [ Tabs.label [] [text "Tab One"]
            , Tabs.textLabel [] "Tab Two"
@@ -114,7 +114,7 @@ view model  =
     [ Tabs.render Mdl [0] model.mdl
         [ Tabs.ripple
         , Tabs.onSelectTab SelectTab
-        , Tabs.selectTab model.tab
+        , Tabs.activeTab model.tab
         ]
         [ Tabs.label [] [text "Example"]
         , Tabs.label [] [text "About ", strong [] [text "Tabs"]]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -1,0 +1,100 @@
+module Demo.Tabs exposing (..)
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+
+import Material.Tabs as Tabs
+import Material
+
+import Demo.Page as Page
+
+
+-- MODEL
+
+
+type alias Mdl =
+  Material.Model
+
+
+type alias Model =
+  { mdl : Material.Model
+  }
+
+
+model : Model
+model =
+  { mdl = Material.model
+  }
+
+
+-- ACTION, UPDATE
+
+
+type Msg
+  = TemplateMsg
+  | Mdl Material.Msg
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+    TemplateMsg ->
+      (model, Cmd.none)
+
+    Mdl action' ->
+      Material.update Mdl action' model
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model  =
+  [ div
+      []
+      [ Tabs.render Mdl [0] model.mdl
+          [ Tabs.ripple ]
+          [ Tabs.tab
+             { panel = Tabs.panel [] [text "Tab One Content"]
+             , link = Tabs.link [] [text "Tab One"]
+             }
+          , Tabs.tab
+             { panel = Tabs.panel [] [text "Tab One Two"]
+             , link = Tabs.link [] [text "Tab Two"]
+             }
+
+          ]
+          -- [ Tabs.tabBar []
+          --     [ Tabs.tabLink [Tabs.active] [text "Tab One"]
+          --     , Tabs.tabLink [] [text "Tab Two"]
+          --     ]
+          -- , Tabs.panel [Tabs.active]
+          --   [text "Panel 1"]
+
+          -- , Tabs.panel []
+          --   [text "Panel 2"]
+          -- ]
+      ]
+  ]
+  |> Page.body2 "TEMPLATE" srcUrl intro references
+
+
+intro : Html m
+intro =
+  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
+> ...
+"""
+
+
+srcUrl : String
+srcUrl =
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+
+
+references : List (String, String)
+references =
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
+  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
+  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  ]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -63,47 +63,51 @@ view model  =
       [ Tabs.tab
           { label =
               Tabs.label
-              []
-              [text "Example"]
+                []
+                [text "Example"]
 
           , content =
-            Tabs.content
-              []
-              [ Code.code """
-                           import Material.Tabs as Tabs
+              Tabs.content
+                []
+                [ Code.code """
+                            import Material.Tabs as Tabs
 
-                           tabs : Model -> Html Msg
-                           tabs model =
-                           Tabs.render Mdl [0] model.mdl
-                           [ Tabs.ripple
-                           , Tabs.onSelectTab SelectTab
-                           , Tabs.selectTab model.tab
-                           ]
+                            tabs : Model -> Html Msg
+                            tabs model =
+                              Tabs.render Mdl [0] model.mdl
+                                  [ Tabs.ripple
+                                  , Tabs.onSelectTab SelectTab
+                                  , Tabs.selectTab model.tab
+                                  ]
+                                  [ Tabs.tab
+                                      { label = Tabs.label [] [text "Tab One"]
+                                      , content = Tabs.content [] [text "Tab One content"]
+                                      }
 
-                           [ Tabs.tab
-                           { label = Tabs.label [] [text "Tab One"]
-                           , content = Tabs.content [] [text "Tab One content"]
-                           }
-                           ]
+                                  , Tabs.tab
+                                      { label = Tabs.label [] [text "Tab Two"]
+                                      , content = Tabs.content [] [text "Tab Two content"]
+                                      }
+                                  ]
 
-                           """
-              ]
+                            """
+                ]
           }
       , Tabs.tab
         { label =
             Tabs.label
-            []
-            [text "About tabs"]
+              []
+              [text "About tabs"]
 
         , content =
-          Tabs.content
-            []
-            [ p []
-                [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
-                ]
-            , p []
-              [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
-            ]
+            Tabs.content
+              []
+              [ p []
+                  [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
+                  ]
+              , p []
+                [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
+              ]
         }
 
 

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -9,6 +9,8 @@ import Material
 import Material.Options as Options
 
 import Demo.Page as Page
+import Demo.Code as Code
+import Markdown as Markdown
 
 
 -- MODEL
@@ -67,6 +69,35 @@ view model  =
           [ Tabs.tab
              { link =
                  Tabs.link
+                   []
+                   [text "Example"]
+
+             , panel =
+                 Tabs.panel
+                   []
+                   [ Code.code """
+                                import Material.Tabs as Tabs
+
+                                tabs : Model -> Html Msg
+                                tabs model =
+                                  Tabs.render Mdl [0] model.mdl
+                                    [ Tabs.ripple
+                                    , Tabs.onSelectTab SelectTab
+                                    , Tabs.selectTab model.tab
+                                    ]
+
+                                    [ Tabs.tab
+                                        { link = Tabs.link [] [text "Tab One"]
+                                        , panel = Tabs.panel [] [text "Tab One content"]
+                                        }
+                                    ]
+
+                                """
+                   ]
+             }
+          , Tabs.tab
+             { link =
+                 Tabs.link
                  []
                  [text "About tabs"]
 
@@ -74,27 +105,13 @@ view model  =
                  Tabs.panel
                    []
                    [ p []
-                       [ b [] [text "Tab"]
-                       , text " component is pretty cool."
-                       ]
-                   , p []
                        [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
                        ]
+                   , p []
+                       [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
                    ]
              }
 
-          , Tabs.tab
-             { link =
-                 Tabs.link
-                   []
-                   [text "Example"]
-
-             , panel =
-                 Tabs.panel
-                   []
-                   [
-                   ]
-             }
 
           ]
       ]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -119,24 +119,38 @@ view model  =
       [ style [("margin-top", "60px")]]
       []
   ]
-  |> Page.body2 "TEMPLATE" srcUrl intro references
+  |> Page.body2 "Tabs" srcUrl intro references
 
 
 intro : Html m
 intro =
-  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
-> ...
+  Page.fromMDL "https://getmdl.io/components/index.html#layout-section/tabs" """
+> The Material Design Lite (MDL) tab component is a user interface element that
+> allows different content blocks to share the same screen space in a mutually
+> exclusive manner. Tabs are always presented in sets of two or more, and they
+> make it easy to explore and switch among different views or functional aspects
+> of an app, or to browse categorized data sets individually. Tabs serve as
+> "headings" for their respective content; the active tab — the one whose content
+> is currently displayed — is always visually distinguished from the others so the
+> user knows which heading the current content belongs to.
+>
+> Tabs are an established but non-standardized feature in user interfaces, and
+> allow users to view different, but often related, blocks of content (often
+> called panels). Tabs save screen real estate and provide intuitive and logical
+> access to data while reducing navigation and associated user confusion. Their
+> design and use is an important factor in the overall user experience. See the
+> tab component's Material Design specifications page for details.
 """
 
 
 srcUrl : String
 srcUrl =
-  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/Tabs.elm"
 
 
 references : List (String, String)
 references =
-  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
-  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Tabs"
+  , Page.mds "https://material.google.com/components/tabs.html"
+  , Page.mdl "https://getmdl.io/components/index.html#layout-section/tabs"
   ]

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -35,7 +35,6 @@ model =
 
 -- ACTION, UPDATE
 
-
 type Msg
   = SelectTab Int
   | Mdl Material.Msg
@@ -45,10 +44,7 @@ update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
     SelectTab idx ->
-      let
-        _ = Debug.log "SELECTED" idx
-      in
-        ({ model | tab = idx }, Cmd.none)
+      ({ model | tab = idx }, Cmd.none)
 
     Mdl action' ->
       Material.update Mdl action' model
@@ -59,67 +55,63 @@ update action model =
 
 view : Model -> Html Msg
 view model  =
-  [ div
-      []
-      [ Tabs.render Mdl [0] model.mdl
-          [ Tabs.ripple
-          , Tabs.onSelectTab SelectTab
-          , Tabs.selectTab model.tab
-          ]
-          [ Tabs.tab
-             { link =
-                 Tabs.link
-                   []
-                   [text "Example"]
+  [ Tabs.render Mdl [0] model.mdl
+      [ Tabs.ripple
+      , Tabs.onSelectTab SelectTab
+      , Tabs.selectTab model.tab
+      ]
+      [ Tabs.tab
+          { link =
+              Tabs.link
+              []
+              [text "Example"]
 
-             , panel =
-                 Tabs.panel
-                   []
-                   [ Code.code """
-                                import Material.Tabs as Tabs
+          , content =
+            Tabs.content
+              []
+              [ Code.code """
+                           import Material.Tabs as Tabs
 
-                                tabs : Model -> Html Msg
-                                tabs model =
-                                  Tabs.render Mdl [0] model.mdl
-                                    [ Tabs.ripple
-                                    , Tabs.onSelectTab SelectTab
-                                    , Tabs.selectTab model.tab
-                                    ]
+                           tabs : Model -> Html Msg
+                           tabs model =
+                           Tabs.render Mdl [0] model.mdl
+                           [ Tabs.ripple
+                           , Tabs.onSelectTab SelectTab
+                           , Tabs.selectTab model.tab
+                           ]
 
-                                    [ Tabs.tab
-                                        { link = Tabs.link [] [text "Tab One"]
-                                        , panel = Tabs.panel [] [text "Tab One content"]
-                                        }
-                                    ]
+                           [ Tabs.tab
+                           { link = Tabs.link [] [text "Tab One"]
+                           , panel = Tabs.panel [] [text "Tab One content"]
+                           }
+                           ]
 
-                                """
-                   ]
-             }
-          , Tabs.tab
-             { link =
-                 Tabs.link
-                 []
-                 [text "About tabs"]
+                           """
+              ]
+          }
+      , Tabs.tab
+        { link =
+            Tabs.link
+            []
+            [text "About tabs"]
 
-             , panel =
-                 Tabs.panel
-                   []
-                   [ p []
-                       [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
-                       ]
-                   , p []
-                       [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
-                   ]
-             }
+        , content =
+          Tabs.content
+            []
+            [ p []
+                [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
+                ]
+            , p []
+              [text """Tabs are an established but non-standardized feature in user interfaces, and allow users to view different, but often related, blocks of content (often called panels). Tabs save screen real estate and provide intuitive and logical access to data while reducing navigation and associated user confusion. Their design and use is an important factor in the overall user experience. See the tab component's Material Design specifications page for details."""]
+            ]
+        }
 
 
-          ]
       ]
   , div
       [ style [("margin-top", "60px")]]
       []
-  ]
-  |> Page.body2 "Tabs" srcUrl intro references
+  ] |> Page.body2 "Tabs" srcUrl intro references
 
 
 intro : Html m

--- a/demo/Demo/Tabs.elm
+++ b/demo/Demo/Tabs.elm
@@ -101,7 +101,7 @@ view model  =
 
         , content =
             Tabs.content
-              []
+              [ Options.css "padding-bottom" "85px" ]
               [ p []
                   [ text """The Material Design Lite (MDL) tab component is a user interface element that allows different content blocks to share the same screen space in a mutually exclusive manner. Tabs are always presented in sets of two or more, and they make it easy to explore and switch among different views or functional aspects of an app, or to browse categorized data sets individually. Tabs serve as "headings" for their respective content; the active tab — the one whose content is currently displayed — is always visually distinguished from the others so the user knows which heading the current content belongs to."""
                   ]
@@ -112,9 +112,6 @@ view model  =
 
 
       ]
-  , div
-      [ style [("margin-top", "60px")]]
-      []
   ] |> Page.body2 "Tabs" srcUrl intro references
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -26,6 +26,7 @@
         "Material.Table",
         "Material.Tooltip",
         "Material.Toggles",
+        "Material.Tabs",
         "Material.Textfield"
     ],
     "dependencies": {

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -173,6 +173,7 @@ import Material.Snackbar as Snackbar
 import Material.Layout as Layout
 import Material.Toggles as Toggles
 import Material.Tooltip as Tooltip
+import Material.Tabs as Tabs
 --import Material.Template as Template
 
 
@@ -188,6 +189,7 @@ type alias Model =
   , layout : Layout.Model
   , toggles : Indexed Toggles.Model
   , tooltip : Indexed Tooltip.Model
+  , tabs : Indexed Tabs.Model
 --  , template : Indexed Template.Model
   }
 
@@ -203,6 +205,7 @@ model =
   , layout = Layout.defaultModel
   , toggles = Dict.empty
   , tooltip = Dict.empty
+  , tabs = Dict.empty
 --  , template = Dict.empty
   }
 

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -1,0 +1,238 @@
+module Material.Tabs exposing
+  (..)
+
+-- TEMPLATE. Copy this to a file for your component, then update.
+
+{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
+
+> ...
+
+See also the
+[Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
+
+Refer to [this site](http://debois.github.io/elm-mdl#/template)
+for a live demo.
+
+@docs Model, model, Msg, update
+@docs view
+
+# Component support
+
+@docs Container, Observer, Instance, instance, fwdTemplate
+-}
+
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (Html)
+import Parts exposing (Indexed)
+import Material.Options as Options exposing (cs, when)
+import Material.Helpers as Helpers
+import Material.Ripple as Ripple
+import Html.App
+import Html.Attributes as Html exposing (class)
+import Html.Events as Html
+
+import Dict exposing (Dict)
+
+-- MODEL
+
+
+{-| Component model.
+-}
+type alias Model =
+  { ripple : Ripple.Model
+  , activeTab : Int
+  }
+
+
+{-| Default component model constructor.
+-}
+defaultModel : Model
+defaultModel =
+  { ripple = Ripple.model
+  , activeTab = 0
+  }
+
+
+-- ACTION, UPDATE
+
+
+{-| Component action.
+-}
+type Msg
+  = Select Int
+  | Ripple Ripple.Msg
+
+
+{-| Component update.
+-}
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+    Select idx ->
+      ({ model | activeTab = idx }, none)
+    Ripple action' ->
+      let
+        (nextRipple, cmd) = Ripple.update action' model.ripple
+      in
+        ({ model | ripple = nextRipple }, Cmd.map (Ripple) cmd)
+
+
+-- PROPERTIES
+
+
+type alias Config =
+  { ripple : Bool
+  }
+
+
+defaultConfig : Config
+defaultConfig =
+  { ripple = False
+  }
+
+
+type alias Property m =
+  Options.Property Config m
+
+
+
+type Panel m =
+  Panel
+  { styles : List (Property m)
+  , content : List (Html m)
+  }
+
+
+type TabLink m =
+  TabLink
+  { styles : List (Property m)
+  , content : List (Html m)
+  }
+
+
+type Tab m =
+  Tab
+  { panel : Panel m
+  , link : TabLink m
+  }
+
+
+
+
+tab : { panel : Panel m, link : TabLink m} -> Tab m
+tab =
+  Tab
+
+panel : List (Property m) -> List (Html m) -> Panel m
+panel styles content =
+  Panel { styles = styles, content = content}
+
+link : List (Property m) -> List (Html m) -> TabLink m
+link styles content =
+  TabLink { styles = styles, content = content}
+
+{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
+-}
+
+active : Property m
+active = cs "is-active"
+
+
+ripple : Property m
+ripple =
+  Options.set (\options -> { options | ripple = True })
+
+-- VIEW
+
+{-| Component view.
+-}
+view : (Msg -> m) -> Model -> List (Property m) -> List (Tab m) -> Html m
+view lift model options tabs =
+
+  let
+    summary = Options.collect defaultConfig options
+    config = summary.config
+
+
+    unwrapPanel idx (Panel { styles, content }) =
+      Options.styled Html.div
+        (cs "mdl-tabs__panel"
+        :: cs "is-active" `when` (idx == model.activeTab)
+        :: styles)
+        content
+
+
+    unwrapLink idx (TabLink { styles, content }) =
+      Options.apply summary Html.a
+        [ cs "mdl-tabs__tab"
+        , cs "is-active" `when` (idx == model.activeTab)
+        ]
+        [ Just (Helpers.blurOn "mouseup")
+        , Just (Helpers.blurOn "mouseleave")
+        , Just (Html.onClick (lift (Select idx)))
+        ]
+        (if config.ripple then
+           List.concat
+           [ content
+           , [ Html.App.map (Ripple >> lift) <| Ripple.view
+                 [ class "mdl-tabs__ripple-container"
+                 , class "mdl-js-ripple-effect"
+                 , Helpers.blurOn "mouseup"
+                 ]
+                 model.ripple
+             ]
+           ]
+         else
+           content)
+
+
+    unwrapTab idx (Tab { panel, link }) =
+      (unwrapPanel idx panel, unwrapLink idx link)
+
+    tabs' = List.indexedMap unwrapTab tabs
+
+    (panels, links') = List.unzip tabs'
+
+    links =
+      Options.styled Html.div
+        (cs "mdl-tabs__tab-bar" :: [])
+        links'
+
+  in
+    Options.apply summary Html.div
+      [ cs "mdl-tabs"
+      , cs "mdl-js-tabs"
+      , cs "is-upgraded"
+      , cs "mdl-js-ripple-effect" `when` config.ripple
+      , cs "mdl-js-ripple-effect--ignore-events" `when` config.ripple
+      ]
+      [ Just (Helpers.blurOn "mouseup")
+      , Just (Helpers.blurOn "mouseleave")
+      ]
+      (links :: panels)
+      --elems
+    -- Options.styled Html.div
+    --   (cs "mdl-tabs mdl-js-tabs" :: options)
+    --   [text "Content"]
+
+
+-- COMPONENT
+
+type alias Container c =
+  { c | tabs : Indexed Model }
+
+
+{-| Component render.
+-}
+render
+  : (Parts.Msg (Container c) -> m)
+  -> Parts.Index
+  -> (Container c)
+  -> List (Property m)
+  -> List (Tab m)
+  -> Html m
+render =
+  Parts.create view update .tabs (\x y -> {y | tabs = x}) defaultModel
+
+{- See src/Material/Layout.mdl for how to add subscriptions. -}

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -1,23 +1,18 @@
 module Material.Tabs
-  exposing (..)
-    -- ( Tab
-    -- , Content
-    -- , Label
-    -- , Property
-    -- , Msg
-    -- , TabContent
-    -- , render
-    -- , update
-    -- , view
-    -- , tab
-    -- , label
-    -- , content
-    -- , ripple
-    -- , onSelectTab
-    -- , selectTab
-    -- , Model
-    -- , defaultModel
-    -- )
+  exposing
+    ( Label
+    , Property
+    , Msg
+    , render
+    , update
+    , view
+    , label
+    , ripple
+    , onSelectTab
+    , selectTab
+    , Model
+    , defaultModel
+    )
 
 {-| From the [Material Design Lite documentation](https://getmdl.io/components/index.html#layout-section/tabs):
 
@@ -44,7 +39,7 @@ Refer to [this site](http://debois.github.io/elm-mdl#/tabs)
 for a live demo.
 
 # Types
-@docs TabContent, Tab, Content, Label
+@docs Label
 @docs Property
 
 # Render
@@ -56,14 +51,15 @@ for a live demo.
 
 @docs onSelectTab, selectTab
 
-# Appearance
 
+# Appearance
 
 @docs ripple
 
+
 # Content
 
-@docs tab, content, label
+@docs label
 
 
 # Elm architecture
@@ -111,7 +107,8 @@ defaultModel =
 
 {-| Component action.
 -}
-type Msg = Ripple Int Ripple.Msg
+type Msg
+  = Ripple Int Ripple.Msg
 
 
 {-| Component update.
@@ -156,13 +153,15 @@ type alias Property m =
 
 {-| Opaque `Label` type
 -}
-type Label m = Label (List (Property m), List (Html m))
+type Label m
+  = Label ( List (Property m), List (Html m) )
 
 
 {-| Create tab `label`
 -}
 label : List (Property m) -> List (Html m) -> Label m
-label p c = Label (p, c)
+label p c =
+  Label ( p, c )
 
 
 {-| Make tabs ripple when clicked.
@@ -205,14 +204,15 @@ view lift model options tabs tabContent =
         , cs "is-active"
         ]
 
-    unwrapLabel tabIdx (Label (props, content)) =
+    unwrapLabel tabIdx (Label ( props, content )) =
       Options.styled Html.a
         ([ cs "mdl-tabs__tab"
          , cs "is-active" `when` (tabIdx == config.activeTab)
          , config.onSelectTab
-         |> Maybe.map (\t -> Internal.attribute <| Html.onClick (t tabIdx))
-         |> Maybe.withDefault Options.nop
-         ] ++ props
+            |> Maybe.map (\t -> Internal.attribute <| Html.onClick (t tabIdx))
+            |> Maybe.withDefault Options.nop
+         ]
+          ++ props
         )
         (if config.ripple then
           List.concat
@@ -233,7 +233,6 @@ view lift model options tabs tabContent =
           content
         )
 
-
     links =
       Options.styled Html.div
         [ cs "mdl-tabs__tab-bar"
@@ -252,8 +251,6 @@ view lift model options tabs tabContent =
       (links :: (wrapContent tabContent) :: [])
 
 
-{-| Component view.
--}
 
 -- COMPONENT
 
@@ -274,5 +271,3 @@ render :
   -> Html m
 render =
   Parts.create view update .tabs (\x y -> { y | tabs = x }) defaultModel
-
-{- See src/Material/Layout.mdl for how to add subscriptions. -}

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -10,7 +10,7 @@ module Material.Tabs
     , textLabel
     , ripple
     , onSelectTab
-    , selectTab
+    , activeTab
     , Model
     , defaultModel
     )
@@ -50,7 +50,7 @@ for a live demo.
 
 # Events
 
-@docs onSelectTab, selectTab
+@docs onSelectTab, activeTab
 
 
 # Appearance
@@ -189,10 +189,10 @@ onSelectTab k =
   Options.set (\config -> { config | onSelectTab = Just k })
 
 
-{-| Set the selected tab.
+{-| Set the active tab.
 -}
-selectTab : Int -> Property m
-selectTab k =
+activeTab : Int -> Property m
+activeTab k =
   Options.set (\config -> { config | activeTab = k })
 
 

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -105,8 +105,8 @@ type alias Property m =
   Options.Property (Config m) m
 
 
-type Panel m
-  = Panel
+type Content m
+  = Content
       { styles : List (Property m)
       , content : List (Html m)
       }
@@ -122,18 +122,18 @@ type TabLink m
 type Tab m
   = Tab
       { link : TabLink m
-      , panel : Panel m
+      , content : Content m
       }
 
 
-tab : { panel : Panel m, link : TabLink m } -> Tab m
+tab : { content : Content m, link : TabLink m } -> Tab m
 tab =
   Tab
 
 
-panel : List (Property m) -> List (Html m) -> Panel m
-panel styles content =
-  Panel { styles = styles, content = content }
+content : List (Property m) -> List (Html m) -> Content m
+content styles content =
+  Content { styles = styles, content = content }
 
 
 link : List (Property m) -> List (Html m) -> TabLink m
@@ -171,7 +171,7 @@ view lift model options tabs =
     config =
       summary.config
 
-    unwrapPanel tabIdx (Panel { styles, content }) =
+    unwrapPanel tabIdx (Content { styles, content }) =
       Options.styled Html.div
         ([ cs "mdl-tabs__panel"
          , cs "is-active" `when` (tabIdx == config.activeTab)
@@ -205,8 +205,8 @@ view lift model options tabs =
           content
         )
 
-    unwrapTab tabIdx (Tab { panel, link }) =
-      ( unwrapPanel tabIdx panel, unwrapLink tabIdx link )
+    unwrapTab tabIdx (Tab { content, link }) =
+      ( unwrapPanel tabIdx content, unwrapLink tabIdx link )
 
     tabs' =
       List.indexedMap unwrapTab tabs

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -7,6 +7,7 @@ module Material.Tabs
     , update
     , view
     , label
+    , textLabel
     , ripple
     , onSelectTab
     , selectTab
@@ -60,6 +61,7 @@ for a live demo.
 # Content
 
 @docs label
+@docs textLabel
 
 
 # Elm architecture
@@ -162,6 +164,15 @@ type Label m
 label : List (Property m) -> List (Html m) -> Label m
 label p c =
   Label ( p, c )
+
+
+{-| Create tab `label` with simple text.
+Most often the labels are just text so this is a
+utility function to help create labels with just text.
+-}
+textLabel : List (Property m) -> String -> Label m
+textLabel p c =
+  label p [ Html.text c ]
 
 
 {-| Make tabs ripple when clicked.

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -111,9 +111,7 @@ defaultModel =
 
 {-| Component action.
 -}
-type Msg
-  = NoOp
-  | Ripple Int Ripple.Msg
+type Msg = Ripple Int Ripple.Msg
 
 
 {-| Component update.
@@ -121,9 +119,6 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update action model =
   case action of
-    NoOp ->
-      ( model, none )
-
     Ripple tabIdx action' ->
       let
         ( ripple', cmd ) =

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -112,8 +112,8 @@ type Content m
       }
 
 
-type TabLink m
-  = TabLink
+type Label m
+  = Label
       { styles : List (Property m)
       , content : List (Html m)
       }
@@ -121,12 +121,12 @@ type TabLink m
 
 type Tab m
   = Tab
-      { link : TabLink m
+      { label : Label m
       , content : Content m
       }
 
 
-tab : { content : Content m, link : TabLink m } -> Tab m
+tab : { content : Content m, label : Label m } -> Tab m
 tab =
   Tab
 
@@ -136,9 +136,9 @@ content styles content =
   Content { styles = styles, content = content }
 
 
-link : List (Property m) -> List (Html m) -> TabLink m
-link styles content =
-  TabLink { styles = styles, content = content }
+label : List (Property m) -> List (Html m) -> Label m
+label styles content =
+  Label { styles = styles, content = content }
 
 
 ripple : Property m
@@ -178,7 +178,7 @@ view lift model options tabs =
          ] ++ styles)
         content
 
-    unwrapLink tabIdx (TabLink { styles, content }) =
+    unwrapLink tabIdx (Label { styles, content }) =
       Options.styled Html.a
         ([ cs "mdl-tabs__tab"
         , cs "is-active" `when` (tabIdx == config.activeTab)
@@ -205,8 +205,8 @@ view lift model options tabs =
           content
         )
 
-    unwrapTab tabIdx (Tab { content, link }) =
-      ( unwrapPanel tabIdx content, unwrapLink tabIdx link )
+    unwrapTab tabIdx (Tab { content, label }) =
+      ( unwrapPanel tabIdx content, unwrapLink tabIdx label )
 
     tabs' =
       List.indexedMap unwrapTab tabs


### PR DESCRIPTION
Initial implementation of `Tabs` component to resolve #56

Took inspiration from Layout tabs, but with strong opaque types for `tabs`, `labels`  and `content`.

One thing I'm not 100% sure about is having the user provide the `onSelectTab` and `selectTab model.tab` for selecting tab. You could do them in the `Tabs.Model` but then the user would not be able to get messages about when a tab has been selected etc.

Example use: 


```elm
import Material.Tabs as Tabs

tabs : Model -> Html Msg
tabs model =
    Tabs.render Mdl [0] model.mdl
        [ Tabs.ripple
        , Tabs.onSelectTab SelectTab
        , Tabs.selectTab model.tab
        ]
        [ Tabs.tab
            { label = Tabs.label [] [text "Tab One"]
            , content = Tabs.content [] [text "Tab One content"]
            }

        , Tabs.tab
            { label = Tabs.label [] [text "Tab Two"]
            , content = Tabs.content [] [text "Tab Two content"]
            }
        ]
```

Open to suggestions and feedback.