### PR TITLE
Initial implementation of Slider Component 

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -33,6 +33,7 @@ import Demo.Layout
 import Demo.Footer
 import Demo.Tooltip
 import Demo.Tabs
+import Demo.Slider
 --import Demo.Template
 
 
@@ -54,6 +55,7 @@ type alias Model =
   , footers : Demo.Footer.Model
   , tooltip : Demo.Tooltip.Model
   , tabs : Demo.Tabs.Model
+  , slider : Demo.Slider.Model
   --, template : Demo.Template.Model
   , selectedTab : Int
   , transparentHeader : Bool
@@ -75,6 +77,7 @@ model =
   , footers = Demo.Footer.model
   , tooltip = Demo.Tooltip.model
   , tabs = Demo.Tabs.model
+  , slider = Demo.Slider.model
   --, template = Demo.Template.model
   , selectedTab = 0
   , transparentHeader = False
@@ -100,6 +103,7 @@ type Msg
   | FooterMsg Demo.Footer.Msg
   | TooltipMsg Demo.Tooltip.Msg
   | TabMsg Demo.Tabs.Msg
+  | SliderMsg Demo.Slider.Msg
   | ToggleHeader
   --| TemplateMsg Demo.Template.Msg
 
@@ -140,6 +144,8 @@ update action model =
     LoadingMsg   a -> lift  .loading    (\m x->{m|loading   =x}) LoadingMsg  Demo.Loading.update    a model
     FooterMsg   a -> lift  .footers    (\m x->{m|footers   =x}) FooterMsg  Demo.Footer.update    a model
 
+    SliderMsg   a -> lift  .slider    (\m x->{m|slider   =x}) SliderMsg  Demo.Slider.update    a model
+
     TooltipMsg   a -> lift  .tooltip    (\m x->{m|tooltip   =x}) TooltipMsg  Demo.Tooltip.update    a model
     TabMsg   a -> lift  .tabs    (\m x->{m|tabs   =x}) TabMsg  Demo.Tabs.update    a model
 
@@ -166,6 +172,7 @@ tabs =
   , ("Tables", "tables", .tables >> Demo.Tables.view >> App.map TablesMsg)
   , ("Tooltips", "tooltips", .tooltip >> Demo.Tooltip.view >> App.map TooltipMsg)
   , ("Tabs", "tabs", .tabs >> Demo.Tabs.view >> App.map TabMsg)
+  , ("Sliders", "sliders", .slider >> Demo.Slider.view >> App.map SliderMsg)
   --, ("Template", "template", .template >> Demo.Template.view >> App.map TemplateMsg)
   ]
 

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -6,7 +6,9 @@ import Html.Attributes as Html
 
 import Material.Slider as Slider
 import Material
+import Material.Grid as Grid
 
+import Demo.Code as Code
 import Demo.Page as Page
 import Dict exposing (Dict)
 
@@ -61,10 +63,43 @@ update action model =
 
 -- VIEW
 
+demoContainer : (Html m, String) -> Grid.Cell m
+demoContainer (html, code) =
+  Grid.cell
+    [Grid.size Grid.All 4]
+    [ Html.div [Html.style [("text-align", "center")]]
+        [html]
+    , Code.code code
+    ]
+
 
 view : Model -> Html Msg
 view model  =
-  [ Html.p
+  [ Html.p [] [text "Example use:"]
+  , Grid.grid[]
+      [ Grid.cell
+          [Grid.size Grid.All 12]
+          [Code.code """
+                        import Material.Slider as Slider
+                      """]
+
+      , demoContainer
+          ( Slider.render Mdl [3] model.mdl
+              [ Slider.onChange (Slider 3)
+              , Slider.value (get 3 model.values)
+              ]
+              []
+          ,
+            """
+            Slider.render Mdl [3] model.mdl
+                          [ Slider.onChange (Slider 3)
+                          , Slider.value """ ++ (toString (get 3 model.values)) ++ """
+                          ]
+                          []
+             """
+          )
+      ]
+  , Html.p
       [ Html.style [("width", "300px")]]
       [ Slider.render Mdl [0] model.mdl
           [ Slider.onChange (Slider 0)

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -1,0 +1,79 @@
+module Demo.Slider exposing (..)
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+import Html.Attributes as Html
+
+import Material.Slider as Slider
+import Material
+
+import Demo.Page as Page
+
+
+-- MODEL
+
+
+type alias Mdl =
+  Material.Model
+
+
+type alias Model =
+  { mdl : Material.Model
+  }
+
+
+model : Model
+model =
+  { mdl = Material.model
+  }
+
+
+-- ACTION, UPDATE
+
+
+type Msg
+  = TemplateMsg
+  | Mdl Material.Msg
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+    TemplateMsg ->
+      (model, Cmd.none)
+
+    Mdl action' ->
+      Material.update Mdl action' model
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model  =
+  [ div
+      [ Html.style [("width", "300px")]]
+      [ Slider.render Mdl [0] model.mdl [] []
+      ]
+  ]
+  |> Page.body2 "Sliders" srcUrl intro references
+
+
+intro : Html m
+intro =
+  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
+> ...
+"""
+
+
+srcUrl : String
+srcUrl =
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+
+
+references : List (String, String)
+references =
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
+  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
+  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  ]

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -88,40 +88,52 @@ view model  =
                       """]
 
       , demoContainer
-          ( Slider.render Mdl [0] model.mdl
+          ( Slider.slider
               [ Slider.onChange (Slider 0)
               , Slider.value (get 0 model.values)
               ]
-              []
           ,
             """
-            Slider.render Mdl [0] model.mdl
-                          [ Slider.onChange SliderMsg
-                          , Slider.value """ ++ (toString (get 0 model.values)) ++ """
-                          ]
-                          []
+            Slider.slider
+              [ Slider.onChange SliderMsg
+              , Slider.value """ ++ (toString (get 0 model.values)) ++ """
+              ]
              """
           )
 
       , demoContainer
-          ( Slider.render Mdl [1] model.mdl
+          ( Slider.slider
               [ Slider.onChange (Slider 1)
               , Slider.value (getDef 1 4.0 model.values)
               , Slider.max 10
               , Slider.min 0
               , Slider.step 2
               ]
-              []
           ,
             """
-            Slider.render Mdl [1] model.mdl
-                          [ Slider.onChange SliderMsg
-                          , Slider.value """ ++ (toString (getDef 1 4.0 model.values)) ++ """
-                          , Slider.max 10
-                          , Slider.min 0
-                          , Slider.step 2
-                          ]
-                          []
+            Slider.slider
+              [ Slider.onChange SliderMsg
+              , Slider.value """ ++ (toString (getDef 1 4.0 model.values)) ++ """
+              , Slider.max 10
+              , Slider.min 0
+              , Slider.step 2
+              ]
+             """
+          )
+
+      , demoContainer
+          ( Slider.slider
+              [ Slider.onChange (Slider 2)
+              , Slider.value (getDef 2 50.0 model.values)
+              , Slider.disabled
+              ]
+          ,
+            """
+            Slider.slider
+              [ Slider.onChange SliderMsg
+              , Slider.value """ ++ (toString (getDef 2 50.0 model.values)) ++ """
+              , Slider.disabled
+              ]
              """
           )
       ]

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -35,10 +35,8 @@ model =
 
 -- ACTION, UPDATE
 
-
 type Msg
-  = SliderMsg Float
-  | Slider Int Float
+  = Slider Int Float
   | Mdl Material.Msg
 
 
@@ -50,11 +48,6 @@ get key dict =
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
-    SliderMsg value ->
-      let
-        _ = []--Debug.log "VALUE" value
-      in
-        ({ model | value = value }, Cmd.none)
 
     Slider idx value ->
       let
@@ -71,8 +64,7 @@ update action model =
 
 view : Model -> Html Msg
 view model  =
-  [ Slider.script scriptHelp
-  , Html.p
+  [ Html.p
       [ Html.style [("width", "300px")]]
       [ Slider.render Mdl [0] model.mdl
           [ Slider.onChange (Slider 0)
@@ -110,43 +102,3 @@ references =
   , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
   , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
   ]
-
-
-scriptHelp : String
-scriptHelp =
-  """
-   function onSliderContainerMouseDown(event) {
-   console.log("original", event)
-    if (event.target.className.indexOf("mdl-slider__container") === -1) {
-        console.log("not slider event", event);
-        return;
-    }
-
-    // Discard the original event and create a new event that
-    // is on the slider element.
-    event.preventDefault();
-
-    var elem = event.target.querySelector('input.mdl-slider');
-
-    var newEvent = new MouseEvent('mousedown', {
-      target: event.target,
-      buttons: event.buttons,
-      clientX: event.clientX,
-      clientY: elem.getBoundingClientRect().y
-    });
-    console.log("new event", newEvent);
-    elem.dispatchEvent(newEvent);
-}
-
-  function setupListeners() {
-    var containers = document.querySelectorAll(".mdl-slider__container");
-    containers.forEach(function(element) {
-        console.log("processing", element)
-        element.removeEventListener('mousedown', onSliderContainerMouseDown);
-        element.addEventListener('mousedown', onSliderContainerMouseDown);
-    });
-}
-
-  setTimeout(setupListeners, 1000);
-
-  """

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -86,6 +86,7 @@ view model  =
       [ Slider.render Mdl [2] model.mdl
           [ Slider.onChange (Slider 2)
           , Slider.value (get 2 model.values)
+          , Slider.disabled
           ]
           []
       ]

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -14,15 +14,8 @@ import Dict exposing (Dict)
 
 
 -- MODEL
-
-
-type alias Mdl =
-  Material.Model
-
-
 type alias Model =
   { mdl : Material.Model
-  , value : Float
   , values : Dict Int Float
   }
 
@@ -30,7 +23,6 @@ type alias Model =
 model : Model
 model =
   { mdl = Material.model
-  , value = 0
   , values = Dict.empty
   }
 
@@ -45,6 +37,7 @@ type Msg
 get : Int -> Dict Int Float -> Float
 get key dict =
   Dict.get key dict |> Maybe.withDefault 0
+
 
 getDef : Int -> Float -> Dict Int Float -> Float
 getDef key def dict =
@@ -85,18 +78,28 @@ view model  =
           [Grid.size Grid.All 12]
           [Code.code """
                         import Material.Slider as Slider
-                      """]
+
+                        slider : Model -> Html Msg 
+                        slider model = 
+                          p [ style [ ("width", "300px") ] ]
+                            [ Slider.slider 
+                                [ Slider.onChange SliderMsg 
+                                , Slider.value model.value  
+                                ]
+                            ]                    
+              """
+          ]
 
       , demoContainer
           ( Slider.slider
               [ Slider.onChange (Slider 0)
-              , Slider.value (get 0 model.values)
+              , Slider.value (getDef 0 50.0 model.values)
               ]
           ,
             """
             Slider.slider
               [ Slider.onChange SliderMsg
-              , Slider.value """ ++ (toString (get 0 model.values)) ++ """
+              , Slider.value """ ++ (toString (getDef 0 50.0 model.values)) ++ """
               ]
              """
           )
@@ -104,18 +107,18 @@ view model  =
       , demoContainer
           ( Slider.slider
               [ Slider.onChange (Slider 1)
-              , Slider.value (getDef 1 4.0 model.values)
+              , Slider.value (getDef 1 0.0 model.values)
               , Slider.max 10
-              , Slider.min 0
+              , Slider.min -10
               , Slider.step 2
               ]
           ,
             """
             Slider.slider
               [ Slider.onChange SliderMsg
-              , Slider.value """ ++ (toString (getDef 1 4.0 model.values)) ++ """
+              , Slider.value """ ++ (toString (getDef 1 0.0 model.values)) ++ """
               , Slider.max 10
-              , Slider.min 0
+              , Slider.min -10
               , Slider.step 2
               ]
              """
@@ -136,7 +139,8 @@ view model  =
               ]
              """
           )
-      ]
+      
+      ]    
   ]
   |> Page.body2 "Sliders" srcUrl intro references
 

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -107,7 +107,7 @@ view model  =
       , demoContainer
           ( Slider.slider
               [ Slider.onChange (Slider 1)
-              , Slider.value (getDef 1 0.0 model.values)
+              , Slider.value (getDef 1 2.0 model.values)
               , Slider.max 10
               , Slider.min -10
               , Slider.step 2
@@ -116,7 +116,7 @@ view model  =
             """
             Slider.slider
               [ Slider.onChange SliderMsg
-              , Slider.value """ ++ (toString (getDef 1 0.0 model.values)) ++ """
+              , Slider.value """ ++ (toString (getDef 1 2.0 model.values)) ++ """
               , Slider.max 10
               , Slider.min -10
               , Slider.step 2

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -8,6 +8,7 @@ import Material.Slider as Slider
 import Material
 
 import Demo.Page as Page
+import Dict exposing (Dict)
 
 
 -- MODEL
@@ -19,12 +20,16 @@ type alias Mdl =
 
 type alias Model =
   { mdl : Material.Model
+  , value : Float
+  , values : Dict Int Float
   }
 
 
 model : Model
 model =
   { mdl = Material.model
+  , value = 0
+  , values = Dict.empty
   }
 
 
@@ -32,15 +37,30 @@ model =
 
 
 type Msg
-  = TemplateMsg
+  = SliderMsg Float
+  | Slider Int Float
   | Mdl Material.Msg
+
+
+get : Int -> Dict Int Float -> Float
+get key dict =
+  Dict.get key dict |> Maybe.withDefault 0
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
-    TemplateMsg ->
-      (model, Cmd.none)
+    SliderMsg value ->
+      let
+        _ = []--Debug.log "VALUE" value
+      in
+        ({ model | value = value }, Cmd.none)
+
+    Slider idx value ->
+      let
+        values = Dict.insert idx value model.values
+      in
+        ({ model | values = values }, Cmd.none)
 
     Mdl action' ->
       Material.update Mdl action' model
@@ -51,9 +71,22 @@ update action model =
 
 view : Model -> Html Msg
 view model  =
-  [ div
+  [ Slider.script scriptHelp
+  , Html.p
       [ Html.style [("width", "300px")]]
-      [ Slider.render Mdl [0] model.mdl [] []
+      [ Slider.render Mdl [0] model.mdl
+          [ Slider.onChange (Slider 0)
+          , Slider.value (get 0 model.values)
+          ]
+          []
+      ]
+  , Html.p
+      [ Html.style [("width", "300px")]]
+      [ Slider.render Mdl [1] model.mdl
+          [ Slider.onChange (Slider 1)
+          , Slider.value (get 1 model.values)
+          ]
+          []
       ]
   ]
   |> Page.body2 "Sliders" srcUrl intro references
@@ -77,3 +110,43 @@ references =
   , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
   , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
   ]
+
+
+scriptHelp : String
+scriptHelp =
+  """
+   function onSliderContainerMouseDown(event) {
+   console.log("original", event)
+    if (event.target.className.indexOf("mdl-slider__container") === -1) {
+        console.log("not slider event", event);
+        return;
+    }
+
+    // Discard the original event and create a new event that
+    // is on the slider element.
+    event.preventDefault();
+
+    var elem = event.target.querySelector('input.mdl-slider');
+
+    var newEvent = new MouseEvent('mousedown', {
+      target: event.target,
+      buttons: event.buttons,
+      clientX: event.clientX,
+      clientY: elem.getBoundingClientRect().y
+    });
+    console.log("new event", newEvent);
+    elem.dispatchEvent(newEvent);
+}
+
+  function setupListeners() {
+    var containers = document.querySelectorAll(".mdl-slider__container");
+    containers.forEach(function(element) {
+        console.log("processing", element)
+        element.removeEventListener('mousedown', onSliderContainerMouseDown);
+        element.addEventListener('mousedown', onSliderContainerMouseDown);
+    });
+}
+
+  setTimeout(setupListeners, 1000);
+
+  """

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -80,25 +80,45 @@ view model  =
           ]
           []
       ]
+
+  , Html.p
+      [ Html.style [("width", "300px")]]
+      [ Slider.render Mdl [2] model.mdl
+          [ Slider.onChange (Slider 2)
+          , Slider.value (get 2 model.values)
+          ]
+          []
+      ]
   ]
   |> Page.body2 "Sliders" srcUrl intro references
 
 
 intro : Html m
 intro =
-  Page.fromMDL "https://www.getmdl.io/components/index.html#TEMPLATE-section" """
-> ...
+  Page.fromMDL "https://getmdl.io/components/index.html#sliders-section" """
+> The Material Design Lite (MDL) slider component is an enhanced version of the
+> new HTML5 `<input type="range">` element. A slider consists of a horizontal line
+> upon which sits a small, movable disc (the thumb) and, typically, text that
+> clearly communicates a value that will be set when the user moves it.
+>
+> Sliders are a fairly new feature in user interfaces, and allow users to choose a
+> value from a predetermined range by moving the thumb through the range (lower
+> values to the left, higher values to the right). Their design and use is an
+> important factor in the overall user experience. See the slider component's
+> [Material Design specifications](https://material.google.com/components/sliders.html) page for details.
+>
+> The enhanced slider component may be initially or programmatically disabled.
 """
 
 
 srcUrl : String
 srcUrl =
-  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/TEMPLATE.elm"
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/Slider.elm"
 
 
 references : List (String, String)
 references =
-  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-TEMPLATE"
-  , Page.mds "https://www.google.com/design/spec/components/TEMPLATE.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#TEMPLATE"
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Slider"
+  , Page.mds "https://material.google.com/components/sliders.html"
+  , Page.mdl "https://getmdl.io/components/index.html#sliders-section"
   ]

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -46,6 +46,10 @@ get : Int -> Dict Int Float -> Float
 get key dict =
   Dict.get key dict |> Maybe.withDefault 0
 
+getDef : Int -> Float -> Dict Int Float -> Float
+getDef key def dict =
+  Dict.get key dict |> Maybe.withDefault def
+
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
@@ -84,46 +88,42 @@ view model  =
                       """]
 
       , demoContainer
-          ( Slider.render Mdl [3] model.mdl
-              [ Slider.onChange (Slider 3)
-              , Slider.value (get 3 model.values)
+          ( Slider.render Mdl [0] model.mdl
+              [ Slider.onChange (Slider 0)
+              , Slider.value (get 0 model.values)
               ]
               []
           ,
             """
-            Slider.render Mdl [3] model.mdl
-                          [ Slider.onChange (Slider 3)
-                          , Slider.value """ ++ (toString (get 3 model.values)) ++ """
+            Slider.render Mdl [0] model.mdl
+                          [ Slider.onChange SliderMsg
+                          , Slider.value """ ++ (toString (get 0 model.values)) ++ """
                           ]
                           []
              """
           )
-      ]
-  , Html.p
-      [ Html.style [("width", "300px")]]
-      [ Slider.render Mdl [0] model.mdl
-          [ Slider.onChange (Slider 0)
-          , Slider.value (get 0 model.values)
-          ]
-          []
-      ]
-  , Html.p
-      [ Html.style [("width", "300px")]]
-      [ Slider.render Mdl [1] model.mdl
-          [ Slider.onChange (Slider 1)
-          , Slider.value (get 1 model.values)
-          ]
-          []
-      ]
 
-  , Html.p
-      [ Html.style [("width", "300px")]]
-      [ Slider.render Mdl [2] model.mdl
-          [ Slider.onChange (Slider 2)
-          , Slider.value (get 2 model.values)
-          , Slider.disabled
-          ]
-          []
+      , demoContainer
+          ( Slider.render Mdl [1] model.mdl
+              [ Slider.onChange (Slider 1)
+              , Slider.value (getDef 1 4.0 model.values)
+              , Slider.max 10
+              , Slider.min 0
+              , Slider.step 2
+              ]
+              []
+          ,
+            """
+            Slider.render Mdl [1] model.mdl
+                          [ Slider.onChange SliderMsg
+                          , Slider.value """ ++ (toString (getDef 1 4.0 model.values)) ++ """
+                          , Slider.max 10
+                          , Slider.min 0
+                          , Slider.step 2
+                          ]
+                          []
+             """
+          )
       ]
   ]
   |> Page.body2 "Sliders" srcUrl intro references

--- a/elm-package.json
+++ b/elm-package.json
@@ -23,6 +23,7 @@
         "Material.Scheme",
         "Material.Snackbar",
         "Material.Spinner",
+        "Material.Slider",
         "Material.Table",
         "Material.Tooltip",
         "Material.Toggles",

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -174,6 +174,7 @@ import Material.Layout as Layout
 import Material.Toggles as Toggles
 import Material.Tooltip as Tooltip
 import Material.Tabs as Tabs
+import Material.Slider as Slider
 --import Material.Template as Template
 
 
@@ -190,6 +191,7 @@ type alias Model =
   , toggles : Indexed Toggles.Model
   , tooltip : Indexed Tooltip.Model
   , tabs : Indexed Tabs.Model
+  , slider : Indexed Slider.Model
 --  , template : Indexed Template.Model
   }
 
@@ -206,6 +208,7 @@ model =
   , toggles = Dict.empty
   , tooltip = Dict.empty
   , tabs = Dict.empty
+  , slider = Dict.empty
 --  , template = Dict.empty
   }
 

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -174,7 +174,6 @@ import Material.Layout as Layout
 import Material.Toggles as Toggles
 import Material.Tooltip as Tooltip
 import Material.Tabs as Tabs
-import Material.Slider as Slider
 --import Material.Template as Template
 
 
@@ -191,7 +190,6 @@ type alias Model =
   , toggles : Indexed Toggles.Model
   , tooltip : Indexed Tooltip.Model
   , tabs : Indexed Tabs.Model
-  , slider : Indexed Slider.Model
 --  , template : Indexed Template.Model
   }
 
@@ -208,7 +206,6 @@ model =
   , toggles = Dict.empty
   , tooltip = Dict.empty
   , tabs = Dict.empty
-  , slider = Dict.empty
 --  , template = Dict.empty
   }
 

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -31,15 +31,17 @@ See also the
 Refer to [this site](http://debois.github.io/elm-mdl#/sliders)
 for a live demo.
 
+*NOTE* Currently does not work properly on [Microsoft Edge](https://github.com/google/material-design-lite/issues/1625)
+
 #View
 
-@docs slider 
+@docs slider
 
-# Properties 
+# Properties
 
 @docs Property
-@docs value, min, max 
-@docs step, disabled 
+@docs value, min, max
+@docs step, disabled
 
 # Events
 
@@ -133,7 +135,18 @@ floatVal =
   (Json.at [ "target", "valueAsNumber" ] Json.float)
 
 
-{-| A slider.
+{-| A slider consists of a horizontal line upon which sits a small, movable disc (the thumb) and, typically, text that clearly communicates a value that will be set when the user moves it. Example use:
+
+    import Material.Slider as Slider
+
+    slider : Model -> Html Msg
+    slider model =
+      p [ style [ ("width", "300px") ] ]
+        [ Slider.slider
+            [ Slider.onChange SliderMsg
+            , Slider.value model.value
+            ]
+        ]
 -}
 slider : List (Property m) -> Html m
 slider options =
@@ -204,12 +217,13 @@ slider options =
               attr "disabled" ""
             else
               Options.nop
+            -- FIX for Firefox problem where you had to click on the 2px tall slider to initiate drag
+          , css "padding" "8px 0"
           ]
           [ Html.type' "range"
           , Html.max (toString config.max)
           , Html.min (toString config.min)
           , Html.step (toString config.step)
-            --, Html.attribute "value" (toString config.value)
           , Html.value (toString config.value)
           , Helpers.blurOn "mouseup"
           ]

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -1,4 +1,14 @@
-module Material.Slider exposing (..)
+module Material.Slider
+  exposing
+    ( Property
+    , value
+    , min
+    , max
+    , step
+    , disabled
+    , onChange
+    , slider
+    )
 
 {-| From the [Material Design Lite documentation](https://material.google.com/components/sliders.html):
 
@@ -21,12 +31,20 @@ See also the
 Refer to [this site](http://debois.github.io/elm-mdl#/sliders)
 for a live demo.
 
-@docs Model, model, Msg, update
-@docs view
+#View
 
-# Component support
+@docs slider 
 
-@docs Container, Observer, Instance, instance, fwdTemplate
+# Properties 
+
+@docs Property
+@docs value, min, max 
+@docs step, disabled 
+
+# Events
+
+@docs onChange
+
 -}
 
 import Html exposing (..)
@@ -39,6 +57,7 @@ import Json.Decode as Json
 
 
 -- PROPERTIES
+
 
 type alias Config m =
   { value : Float
@@ -61,6 +80,8 @@ defaultConfig =
   }
 
 
+{-| Properties for Slider options.
+-}
 type alias Property m =
   Options.Property (Config m) m
 
@@ -109,9 +130,11 @@ onChange l =
 
 floatVal : Json.Decoder Float
 floatVal =
-  Debug.log "JSON" (Json.at [ "target", "valueAsNumber" ] Json.float)
+  (Json.at [ "target", "valueAsNumber" ] Json.float)
 
 
+{-| A slider.
+-}
 slider : List (Property m) -> Html m
 slider options =
   let
@@ -193,4 +216,3 @@ slider options =
           []
       , background
       ]
-

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -1,0 +1,170 @@
+module Material.Slider exposing
+  ( Model, defaultModel, Msg, update, view
+  , Property
+  , render
+  )
+
+-- TEMPLATE. Copy this to a file for your component, then update.
+
+{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
+
+> ...
+
+See also the
+[Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
+
+Refer to [this site](http://debois.github.io/elm-mdl#/template)
+for a live demo.
+
+@docs Model, model, Msg, update
+@docs view
+
+# Component support
+
+@docs Container, Observer, Instance, instance, fwdTemplate
+-}
+
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+import Html.Attributes as Html
+import Html.Events as Html
+
+import Parts exposing (Indexed)
+import Material.Options as Options exposing (Style, cs, css)
+
+
+-- MODEL
+
+
+{-| Component model.
+-}
+type alias Model =
+  {
+  }
+
+
+{-| Default component model constructor.
+-}
+defaultModel : Model
+defaultModel =
+  {
+  }
+
+
+-- ACTION, UPDATE
+
+
+{-| Component action.
+-}
+type Msg
+  = MyMsg
+
+
+{-| Component update.
+-}
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  (model, none)
+
+
+-- PROPERTIES
+
+
+type alias Config =
+  {
+  }
+
+
+defaultConfig : Config
+defaultConfig =
+  {
+  }
+
+
+type alias Property m =
+  Options.Property Config m
+
+
+{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
+-}
+
+
+-- VIEW
+{-
+  MaterialSlider.prototype.CssClasses_ = {
+    IE_CONTAINER: 'mdl-slider__ie-container',
+    SLIDER_CONTAINER: 'mdl-slider__container',
+    BACKGROUND_FLEX: 'mdl-slider__background-flex',
+    BACKGROUND_LOWER: 'mdl-slider__background-lower',
+    BACKGROUND_UPPER: 'mdl-slider__background-upper',
+    IS_LOWEST_VALUE: 'is-lowest-value',
+    IS_UPGRADED: 'is-upgraded'
+  };
+-}
+
+
+{-| Component view.
+-}
+view : (Msg -> m) -> Model -> List (Property m) -> List (Html m) -> Html m
+view lift model options elems =
+  let
+    summary =
+      Options.collect defaultConfig options
+
+    config =
+      summary.config
+
+    background =
+      Options.styled Html.div
+        [cs "mdl-slider__background-flex"]
+        [ Options.styled Html.div
+            [ cs "mdl-slider__background-lower"
+            , css "flex" "0 1 0%"
+            ]
+            []
+        , Options.styled Html.div
+            [ cs "mdl-slider__background-upper"
+            , css "flex" "1 1 0%"
+            ]
+            []
+        ]
+  in
+    Options.styled Html.div
+      [cs "mdl-slider__container"]
+      [ Html.input
+          [ Html.classList [ ("mdl-slider", True)
+                           , ("mdl-js-slider", True)
+                           , ("is-upgraded", True)
+                           , ("is-lowest-value", True)
+                           ]
+
+          , Html.type' "range"
+          , Html.min "0"
+          , Html.max "100"
+          , Html.value "0"
+          ]
+          []
+      , background
+      ]
+
+
+-- COMPONENT
+
+type alias Container c =
+  { c | slider : Indexed Model }
+
+
+{-| Component render.
+-}
+render
+  : (Parts.Msg (Container c) -> m)
+  -> Parts.Index
+  -> (Container c)
+  -> List (Property m)
+  -> List (Html m)
+  -> Html m
+render =
+  Parts.create view update .slider (\x y -> {y | slider = x}) defaultModel
+
+{- See src/Material/Layout.mdl for how to add subscriptions. -}

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -29,56 +29,16 @@ for a live demo.
 @docs Container, Observer, Instance, instance, fwdTemplate
 -}
 
--- TEMPLATE. Copy this to a file for your component, then update.
-
-import Platform.Cmd exposing (Cmd, none)
 import Html exposing (..)
 import Html.Attributes as Html
 import Html.Events as Html
-import Parts exposing (Indexed)
 import Material.Options as Options exposing (cs, css, when)
 import Material.Options.Internal as Internal
 import Material.Helpers as Helpers
 import Json.Decode as Json
-import DOM
-
-
--- MODEL
-
-
-{-| Component model.
--}
-type alias Model =
-  {}
-
-
-{-| Default component model constructor.
--}
-defaultModel : Model
-defaultModel =
-  {}
-
-
-
--- ACTION, UPDATE
-
-
-{-| Component action.
--}
-type Msg
-  = MyMsg
-
-
-{-| Component update.
--}
-update : Msg -> Model -> ( Model, Cmd Msg )
-update action model =
-  ( model, none )
-
 
 
 -- PROPERTIES
-
 
 type alias Config m =
   { value : Float
@@ -147,18 +107,13 @@ onChange l =
   Options.set (\options -> { options | listener = Just l })
 
 
--- VIEW
-
-
 floatVal : Json.Decoder Float
 floatVal =
   Debug.log "JSON" (Json.at [ "target", "valueAsNumber" ] Json.float)
 
 
-{-| Component view.
--}
-view : (Msg -> m) -> Model -> List (Property m) -> List (Html m) -> Html m
-view lift model options elems =
+slider : List (Property m) -> Html m
+slider options =
   let
     summary =
       Options.collect defaultConfig options
@@ -191,7 +146,6 @@ view lift model options elems =
             ]
             []
         ]
-
 
     attr : String -> String -> Property m
     attr a v =
@@ -231,33 +185,12 @@ view lift model options elems =
           [ Html.type' "range"
           , Html.max (toString config.max)
           , Html.min (toString config.min)
-          , Html.step (toString  config.step)
-          
-          , Html.attribute "value" (toString config.value)
-          --, Html.attribute "value" "0"
+          , Html.step (toString config.step)
+            --, Html.attribute "value" (toString config.value)
+          , Html.value (toString config.value)
           , Helpers.blurOn "mouseup"
           ]
           []
       , background
       ]
 
-
-
--- COMPONENT
-
-
-type alias Container c =
-  { c | slider : Indexed Model }
-
-
-{-| Component render.
--}
-render :
-  (Parts.Msg (Container c) -> m)
-  -> Parts.Index
-  -> Container c
-  -> List (Property m)
-  -> List (Html m)
-  -> Html m
-render =
-  Parts.create view update .slider (\x y -> { y | slider = x }) defaultModel

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -84,58 +84,69 @@ type alias Config m =
   { value : Float
   , min : Float
   , max : Float
+  , step : Float
   , listener : Maybe (Float -> m)
   , disabled : Bool
-  , step : Float
   }
 
 
 defaultConfig : Config m
 defaultConfig =
-  { value = 0
+  { value = 50
   , min = 0
   , max = 100
+  , step = 1
   , listener = Nothing
   , disabled = False
-  , step = 1
   }
 
 type alias Property m =
   Options.Property (Config m) m
 
 
+{-| Sets current value
+-}
 value : Float -> Property m
 value v =
   Options.set (\options -> { options | value = v })
 
-
+{-| Sets the step. Defaults to 0
+-}
 min : Float -> Property m
 min v =
   Options.set (\options -> { options | min = v })
 
-
+{-| Sets the step. Defaults to 100
+-}
 max : Float -> Property m
 max v =
   Options.set (\options -> { options | max = v })
 
 
+{-| Sets the step. Defaults to 1
+-}
 step : Float -> Property m
 step v =
   Options.set (\options -> { options | step = v })
 
 
+{-| Disables the slider
+-}
 disabled : Property m
 disabled =
   Options.set (\options -> { options | disabled = True })
 
 
+{-| onChange listener for slider values
+-}
 onChange : (Float -> m) -> Property m
 onChange l =
   Options.set (\options -> { options | listener = Just l })
 
 
 
-{- See src/Material/Button.elm for an example of, e.g., an onClick handler. -}
+{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
+ -}
 -- VIEW
 
 
@@ -225,40 +236,6 @@ view lift model options elems =
           , Helpers.blurOn "mouseup"
           ]
           []
-
-       -- Html.input
-       --    [ Html.classList
-       --        [ ( "mdl-slider", True )
-       --        , ( "mdl-js-slider", True )
-       --        , ( "is-upgraded", True )
-       --        , ( "is-lowest-value", fraction == 0 )
-       --        ]
-       --    , Html.type' "range"
-       --    , Html.min "0"
-       --    , Html.max "100"
-       --      --, Html.value
-       --    , Html.attribute "value" "0"
-
-       --    , if config.disabled then
-       --        Html.attribute "disabled" ""
-       --      else
-       --        Helpers.noAttr
-
-       --    , case config.listener of
-       --        Just l ->
-       --          Html.on "change" (Json.map l floatVal)
-
-       --        Nothing ->
-       --          Helpers.noAttr
-       --    , case config.listener of
-       --        Just l ->
-       --          Html.on "input" (Json.map l floatVal)
-
-       --        Nothing ->
-       --          Helpers.noAttr
-       --    , Helpers.blurOn "mouseup"
-       --    ]
-       --    []
       , background
       ]
 

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -1,13 +1,24 @@
 module Material.Slider exposing (..)
 
-{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
+{-| From the [Material Design Lite documentation](https://material.google.com/components/sliders.html):
 
-> ...
+> The Material Design Lite (MDL) slider component is an enhanced version of the
+> new HTML5 `<input type="range">` element. A slider consists of a horizontal line
+> upon which sits a small, movable disc (the thumb) and, typically, text that
+> clearly communicates a value that will be set when the user moves it.
+>
+> Sliders are a fairly new feature in user interfaces, and allow users to choose a
+> value from a predetermined range by moving the thumb through the range (lower
+> values to the left, higher values to the right). Their design and use is an
+> important factor in the overall user experience. See the slider component's
+> [Material Design specifications](https://material.google.com/components/sliders.html) page for details.
+>
+> The enhanced slider component may be initially or programmatically disabled.
 
 See also the
-[Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
+[Material Design Specification](https://material.google.com/components/sliders.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/template)
+Refer to [this site](http://debois.github.io/elm-mdl#/sliders)
 for a live demo.
 
 @docs Model, model, Msg, update
@@ -74,6 +85,7 @@ type alias Config m =
   , min : Float
   , max : Float
   , listener : Maybe (Float -> m)
+  , disabled : Bool
   }
 
 
@@ -83,6 +95,7 @@ defaultConfig =
   , min = 0
   , max = 100
   , listener = Nothing
+  , disabled = False
   }
 
 
@@ -93,6 +106,11 @@ type alias Property m =
 value : Float -> Property m
 value v =
   Options.set (\options -> { options | value = v })
+
+
+disabled : Property m
+disabled =
+  Options.set (\options -> { options | disabled = True })
 
 
 onChange : (Float -> m) -> Property m

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -1,7 +1,4 @@
-module Material.Slider exposing
-  (..)
-
--- TEMPLATE. Copy this to a file for your component, then update.
+module Material.Slider exposing (..)
 
 {-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#TEMPLATE-section):
 
@@ -21,17 +18,16 @@ for a live demo.
 @docs Container, Observer, Instance, instance, fwdTemplate
 -}
 
+-- TEMPLATE. Copy this to a file for your component, then update.
 
 import Platform.Cmd exposing (Cmd, none)
 import Html exposing (..)
 import Html.Attributes as Html
 import Html.Events as Html
-
 import Parts exposing (Indexed)
 import Material.Options as Options exposing (cs, css)
 import Material.Options.Internal as Internal
 import Material.Helpers as Helpers
-
 import Json.Decode as Json
 import DOM
 
@@ -42,16 +38,15 @@ import DOM
 {-| Component model.
 -}
 type alias Model =
-  {
-  }
+  {}
 
 
 {-| Default component model constructor.
 -}
 defaultModel : Model
 defaultModel =
-  {
-  }
+  {}
+
 
 
 -- ACTION, UPDATE
@@ -65,9 +60,10 @@ type Msg
 
 {-| Component update.
 -}
-update : Msg -> Model -> (Model, Cmd Msg)
+update : Msg -> Model -> ( Model, Cmd Msg )
 update action model =
-  (model, none)
+  ( model, none )
+
 
 
 -- PROPERTIES
@@ -94,7 +90,6 @@ type alias Property m =
   Options.Property (Config m) m
 
 
-
 value : Float -> Property m
 value v =
   Options.set (\options -> { options | value = v })
@@ -104,59 +99,16 @@ onChange : (Float -> m) -> Property m
 onChange l =
   Options.set (\options -> { options | listener = Just l })
 
-{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
--}
 
 
+{- See src/Material/Button.elm for an example of, e.g., an onClick handler. -}
 -- VIEW
-{-
-  MaterialSlider.prototype.CssClasses_ = {
-    IE_CONTAINER: 'mdl-slider__ie-container',
-    SLIDER_CONTAINER: 'mdl-slider__container',
-    BACKGROUND_FLEX: 'mdl-slider__background-flex',
-    BACKGROUND_LOWER: 'mdl-slider__background-lower',
-    BACKGROUND_UPPER: 'mdl-slider__background-upper',
-    IS_LOWEST_VALUE: 'is-lowest-value',
-    IS_UPGRADED: 'is-upgraded'
-  };
--}
 
-onContainerClick : Html.Attribute m
-onContainerClick = """
-(function(event) {
-    if (event.target.className.indexOf("mdl-slider__container") === -1) {
-        console.log("not slider event", event);
-        return;
-    }
-
-    // Discard the original event and create a new event that
-    // is on the slider element.
-    event.preventDefault();
-
-    var elem = event.target.querySelector('input.mdl-slider');
-
-    var newEvent = new MouseEvent('mousedown', {
-      target: event.target,
-      buttons: event.buttons,
-      clientX: event.clientX,
-      clientY: elem.getBoundingClientRect().y
-    });
-    console.log("new event", newEvent);
-    elem.dispatchEvent(newEvent);
-
-})(window.event);
-
-  """
-    |> Html.attribute "onmousedown"
 
 floatVal : Json.Decoder Float
 floatVal =
-  Debug.log "JSON" (Json.at ["target", "valueAsNumber"] Json.float)
+  Debug.log "JSON" (Json.at [ "target", "valueAsNumber" ] Json.float)
 
-
-script : String -> Html m
-script src =
-  Html.node "script" [] [Html.text src]
 
 {-| Component view.
 -}
@@ -169,15 +121,20 @@ view lift model options elems =
     config =
       summary.config
 
-    fraction = (config.value - config.min) / (config.max - config.min)
+    fraction =
+      (config.value - config.min) / (config.max - config.min)
 
+    lower =
+      (toString fraction) ++ " 1 0%"
 
-    lower = (toString fraction) ++ " 1 0%"
-    upper = (toString (1 - fraction)) ++ " 1 0%"
+    upper =
+      (toString (1 - fraction)) ++ " 1 0%"
 
+    -- NOTE: does not work with IE yet. needs mdl-slider__ie-container
+    -- and some additional logic
     background =
       Options.styled Html.div
-        [cs "mdl-slider__background-flex"]
+        [ cs "mdl-slider__background-flex" ]
         [ Options.styled Html.div
             [ cs "mdl-slider__background-lower"
             , css "flex" lower
@@ -192,27 +149,31 @@ view lift model options elems =
   in
     Options.styled Html.div
       [ cs "mdl-slider__container"
-      --, Internal.attribute <| (Html.attribute "onmousedown" "onSliderContainerMouseDown(window.event);")
       ]
       [ Html.input
-          [ Html.classList [ ("mdl-slider", True)
-                           , ("mdl-js-slider", True)
-                           , ("is-upgraded", True)
-                           , ("is-lowest-value", fraction == 0)
-                           ]
-
+          [ Html.classList
+              [ ( "mdl-slider", True )
+              , ( "mdl-js-slider", True )
+              , ( "is-upgraded", True )
+              , ( "is-lowest-value", fraction == 0 )
+              ]
           , Html.type' "range"
           , Html.min "0"
           , Html.max "100"
-          --, Html.value
+            --, Html.value
           , Html.attribute "value" "0"
           , case config.listener of
-              Just l -> Html.on "change" (Json.map l floatVal)
-              Nothing -> Helpers.noAttr
-          , case config.listener of
-              Just l -> Html.on "input" (Json.map l floatVal)
-              Nothing -> Helpers.noAttr
+              Just l ->
+                Html.on "change" (Json.map l floatVal)
 
+              Nothing ->
+                Helpers.noAttr
+          , case config.listener of
+              Just l ->
+                Html.on "input" (Json.map l floatVal)
+
+              Nothing ->
+                Helpers.noAttr
           , Helpers.blurOn "mouseup"
           ]
           []
@@ -220,7 +181,9 @@ view lift model options elems =
       ]
 
 
+
 -- COMPONENT
+
 
 type alias Container c =
   { c | slider : Indexed Model }
@@ -228,14 +191,12 @@ type alias Container c =
 
 {-| Component render.
 -}
-render
-  : (Parts.Msg (Container c) -> m)
+render :
+  (Parts.Msg (Container c) -> m)
   -> Parts.Index
-  -> (Container c)
+  -> Container c
   -> List (Property m)
   -> List (Html m)
   -> Html m
 render =
-  Parts.create view update .slider (\x y -> {y | slider = x}) defaultModel
-
-{- See src/Material/Layout.mdl for how to add subscriptions. -}
+  Parts.create view update .slider (\x y -> { y | slider = x }) defaultModel

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -100,6 +100,7 @@ defaultConfig =
   , disabled = False
   }
 
+
 type alias Property m =
   Options.Property (Config m) m
 
@@ -110,11 +111,13 @@ value : Float -> Property m
 value v =
   Options.set (\options -> { options | value = v })
 
+
 {-| Sets the step. Defaults to 0
 -}
 min : Float -> Property m
 min v =
   Options.set (\options -> { options | min = v })
+
 
 {-| Sets the step. Defaults to 100
 -}
@@ -144,25 +147,12 @@ onChange l =
   Options.set (\options -> { options | listener = Just l })
 
 
-
-{- See src/Material/Button.elm for an example of, e.g., an onClick handler.
- -}
 -- VIEW
 
 
 floatVal : Json.Decoder Float
 floatVal =
   Debug.log "JSON" (Json.at [ "target", "valueAsNumber" ] Json.float)
-
-
-type' : String -> Property m
-type' tp =
-  Internal.attribute <| Html.type' tp
-
-
-attr : String -> String -> Property m
-attr a v =
-  (Html.attribute a v) |> Internal.attribute
 
 
 {-| Component view.
@@ -202,15 +192,24 @@ view lift model options elems =
             []
         ]
 
+
+    attr : String -> String -> Property m
+    attr a v =
+      (Html.attribute a v) |> Internal.attribute
+
     onchange =
       case config.listener of
-        Nothing -> Options.nop
+        Nothing ->
+          Options.nop
+
         Just fun ->
           Internal.attribute <| Html.on "change" (Json.map fun floatVal)
 
     oninput =
       case config.listener of
-        Nothing -> Options.nop
+        Nothing ->
+          Options.nop
+
         Just fun ->
           Internal.attribute <| Html.on "input" (Json.map fun floatVal)
   in
@@ -232,7 +231,10 @@ view lift model options elems =
           [ Html.type' "range"
           , Html.max (toString config.max)
           , Html.min (toString config.min)
+          , Html.step (toString  config.step)
+          
           , Html.attribute "value" (toString config.value)
+          --, Html.attribute "value" "0"
           , Helpers.blurOn "mouseup"
           ]
           []


### PR DESCRIPTION
Initial implementation of a `Slider` component to resolve #69.

Did a major refactor of the API based on the [discussion](https://github.com/debois/elm-mdl/issues/69).

The component does not currently use or support `Parts` component model because the component itself has no need for `update` because of the user having to provide both `onChange` and `value` calls to update the slider.

`Slider` does not currently work properly on [Microsoft Edge](https://github.com/google/material-design-lite/issues/1625). It also does not currently look the best on regular Internet Explorer due to flexbox. However, it is functional.

Example use: 

```elm 
import Material.Slider as Slider

slider : Model -> Html Msg
slider model =
    p [ style [ ("width", "300px") ] ]
    [ Slider.slider
        [ Slider.onChange SliderMsg
        , Slider.value model.value
        ]
    ]
```

This follows the `MDL` of wrapping the actual slider in a separate element that has a width specified.