### PR TITLE
Typography

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -34,6 +34,7 @@ import Demo.Footer
 import Demo.Tooltip
 import Demo.Tabs
 import Demo.Slider
+import Demo.Typography
 --import Demo.Template
 
 
@@ -56,6 +57,7 @@ type alias Model =
   , tooltip : Demo.Tooltip.Model
   , tabs : Demo.Tabs.Model
   , slider : Demo.Slider.Model
+  , typography : Demo.Typography.Model
   --, template : Demo.Template.Model
   , selectedTab : Int
   , transparentHeader : Bool
@@ -78,6 +80,7 @@ model =
   , tooltip = Demo.Tooltip.model
   , tabs = Demo.Tabs.model
   , slider = Demo.Slider.model
+  , typography = Demo.Typography.model
   --, template = Demo.Template.model
   , selectedTab = 0
   , transparentHeader = False
@@ -104,6 +107,7 @@ type Msg
   | TooltipMsg Demo.Tooltip.Msg
   | TabMsg Demo.Tabs.Msg
   | SliderMsg Demo.Slider.Msg
+  | TypographyMsg Demo.Typography.Msg
   | ToggleHeader
   --| TemplateMsg Demo.Template.Msg
 
@@ -149,6 +153,7 @@ update action model =
     TooltipMsg   a -> lift  .tooltip    (\m x->{m|tooltip   =x}) TooltipMsg  Demo.Tooltip.update    a model
     TabMsg   a -> lift  .tabs    (\m x->{m|tabs   =x}) TabMsg  Demo.Tabs.update    a model
 
+    TypographyMsg  a -> lift  .typography   (\m x->{m|typography  =x}) TypographyMsg Demo.Typography.update   a model
 
     --TemplateMsg  a -> lift  .template   (\m x->{m|template  =x}) TemplateMsg Demo.Template.update   a model
 
@@ -173,6 +178,7 @@ tabs =
   , ("Tabs", "tabs", .tabs >> Demo.Tabs.view >> App.map TabMsg)
   , ("Toggles", "toggles", .toggles >> Demo.Toggles.view >> App.map TogglesMsg)
   , ("Tooltips", "tooltips", .tooltip >> Demo.Tooltip.view >> App.map TooltipMsg)
+  , ("Typography", "typography", .typography >> Demo.Typography.view >> App.map TypographyMsg)
   --, ("Template", "template", .template >> Demo.Template.view >> App.map TemplateMsg)
   ]
 

--- a/demo/Demo/Typography.elm
+++ b/demo/Demo/Typography.elm
@@ -1,0 +1,205 @@
+module Demo.Typography exposing (..)
+
+import Platform.Cmd exposing (Cmd, none)
+import Html exposing (..)
+import Html.Attributes as Html exposing (class, classList)
+
+import Material.Typography as Typo
+import Material
+import Material.Grid as Grid
+
+import Demo.Page as Page
+import Demo.Code as Code
+
+
+-- MODEL
+
+
+type alias Mdl =
+  Material.Model
+
+
+type alias Model =
+  { mdl : Material.Model
+  }
+
+
+model : Model
+model =
+  { mdl = Material.model
+  }
+
+
+-- ACTION, UPDATE
+
+
+type Msg
+  = TypographyMsg
+  | Mdl Material.Msg
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
+  case action of
+    TypographyMsg ->
+      (model, Cmd.none)
+
+    Mdl action' ->
+      Material.update Mdl action' model
+
+
+
+typoDemo : (Html m, String) -> Grid.Cell m
+typoDemo (html, code) =
+  Grid.cell [Grid.size Grid.All 4]
+    [ div [] [ html ]
+    , Code.code code
+    ]
+
+
+
+typoRow : (Html m, String) -> Html m
+typoRow (html, code) =
+  tr []
+    [ td [ Html.style [("padding-right", "40px")]] [Code.code code]
+    , td [ Html.style [("padding-left", "40px")]] [html]
+    ]
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model  =
+  [ Grid.grid []
+      [ Grid.cell [Grid.size Grid.All 12]
+          [ p [] [text "Example use: "]
+          , Code.code """
+                       import Material.Typography as Typo
+                       """
+          ]
+
+
+      , Grid.cell [ Grid.size Grid.All 12 ]
+        [ table []
+            [ tbody []
+                [ typoRow
+                   ( p [ Typo.display4 ] [text "Light 112px"]
+                   , """
+                      p [ Typo.display4 ]
+                        [ text "Light 112px" ]
+                      """
+                   )
+
+                , typoRow
+                      ( p [ Typo.display3 ] [text "Regular 56px" ]
+                      , """
+                        p [ Typo.display3 ]
+                          [text "Regular 56px" ]
+                        """
+                      )
+
+                , typoRow
+                      ( p [ Typo.display2 ] [text "Regular 45px"]
+                      , """
+                        p [ Typo.display2 ]
+                          [text "Regular 45px"]
+                        """
+                      )
+
+                 , typoRow
+                   ( p [ Typo.display1 ] [text "Regular 34px"]
+                   , """
+                      p [ Typo.display1 ]
+                        [ text "Regular 34px" ]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.headline ] [text "Regular 24px"]
+                   , """
+                      p [ Typo.headline ]
+                        [text "Regular 24px"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.title ] [text "Medium 20px"]
+                   , """
+                      p [ Typo.title ]
+                        [text "Medium 20px"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
+                   , """
+                      p [ Typo.subheading ]
+                        [text "Regular 16px (Device), Regular 15px (Desktop)"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   , """
+                      p [ Typo.body2 ]
+                        [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
+                   , """
+                      p [ Typo.body1 ]
+                        [text "Regular 14px (Device), Regular 13px (Desktop)"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.caption ] [text "Regular 12px"]
+                   , """
+                      p [ Typo.caption ]
+                        [text "Regular 12px"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.button ] [text "Medium (All Caps) 14px"]
+                   , """
+                      p [ Typo.button ]
+                        [text "Medium (All Caps) 14px"]
+                      """
+                   )
+
+                 , typoRow
+                   ( p [ Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   , """
+                      p [ Typo.menu ]
+                        [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                      """
+                   )
+                ]
+            ]
+        ]
+      ]
+  ]
+  |> Page.body2 "Typography" srcUrl intro references
+
+
+intro : Html m
+intro =
+  Page.fromMDL "https://www.getmdl.io/components/index.html#Typography-section" """
+> ...
+"""
+
+
+srcUrl : String
+srcUrl =
+  "https://github.com/debois/elm-mdl/blob/master/demo/Demo/Typography.elm"
+
+
+references : List (String, String)
+references =
+  [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Typography"
+  , Page.mds "https://www.google.com/design/spec/components/Typography.html"
+  , Page.mdl "https://www.getmdl.io/components/index.html#Typography"
+  ]

--- a/demo/Demo/Typography.elm
+++ b/demo/Demo/Typography.elm
@@ -65,6 +65,21 @@ typoRow (html, code) =
     , td [ Html.style [("padding-left", "40px")]] [html]
     ]
 
+
+typoRow' : (Html m, String) -> Html m
+typoRow' (html, code) =
+  tr []
+    [ td [ Html.style [ ("padding-right", "40px")
+                      ]
+         ]
+        [Code.code code]
+    , td [ Html.style [ ("padding-left", "40px")
+                      , ("width", "45%")
+                      ]
+         ]
+        [html]
+    ]
+
 -- VIEW
 
 
@@ -78,117 +93,196 @@ view model  =
                        """
           ]
 
-
       , Grid.cell [ Grid.size Grid.All 12 ]
         [ table []
             [ tbody []
                 [ typoRow
-                   ( p [ Typo.display4 ] [text "Light 112px"]
+                   ( p [ class Typo.display4 ] [text "Light 112px"]
                    , """
-                      p [ Typo.display4 ]
+                      p [ class Typo.display4 ]
                         [ text "Light 112px" ]
                       """
                    )
 
                 , typoRow
-                      ( p [ Typo.display3 ] [text "Regular 56px" ]
+                      ( p [ class Typo.display3 ] [text "Regular 56px" ]
                       , """
-                        p [ Typo.display3 ]
+                        p [ class Typo.display3 ]
                           [text "Regular 56px" ]
                         """
                       )
 
                 , typoRow
-                      ( p [ Typo.display2 ] [text "Regular 45px"]
+                      ( p [ class Typo.display2 ] [text "Regular 45px"]
                       , """
-                        p [ Typo.display2 ]
+                        p [ class Typo.display2 ]
                           [text "Regular 45px"]
                         """
                       )
 
                  , typoRow
-                   ( p [ Typo.display1 ] [text "Regular 34px"]
+                   ( p [ class Typo.display1 ] [text "Regular 34px"]
                    , """
-                      p [ Typo.display1 ]
+                      p [ class Typo.display1 ]
                         [ text "Regular 34px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.headline ] [text "Regular 24px"]
+                   ( p [ class Typo.headline ] [text "Regular 24px"]
                    , """
-                      p [ Typo.headline ]
+                      p [ class Typo.headline ]
                         [text "Regular 24px"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.title ] [text "Medium 20px"]
+                   ( p [ class Typo.title ] [text "Medium 20px"]
                    , """
-                      p [ Typo.title ]
+                      p [ class Typo.title ]
                         [text "Medium 20px"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
+                   ( p [ class Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
                    , """
-                      p [ Typo.subheading ]
+                      p [ class Typo.subheading ]
                         [text "Regular 16px (Device), Regular 15px (Desktop)"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   ( p [ class Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
-                      p [ Typo.body2 ]
+                      p [ class Typo.body2 ]
                         [text "Medium 14px (Device), Medium 13px (Desktop)"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
+                   ( p [ class Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
                    , """
-                      p [ Typo.body1 ]
+                      p [ class Typo.body1 ]
                         [text "Regular 14px (Device), Regular 13px (Desktop)"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.caption ] [text "Regular 12px"]
+                   ( p [ class Typo.caption ] [text "Regular 12px"]
                    , """
-                      p [ Typo.caption ]
+                      p [ class Typo.caption ]
                         [text "Regular 12px"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.button ] [text "Medium (All Caps) 14px"]
+                   ( p [ class Typo.button ] [text "Medium (All Caps) 14px"]
                    , """
-                      p [ Typo.button ]
+                      p [ class Typo.button ]
                         [text "Medium (All Caps) 14px"]
                       """
                    )
 
                  , typoRow
-                   ( p [ Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   ( p [ class Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
-                      p [ Typo.menu ]
+                      p [ class Typo.menu ]
                         [text "Medium 14px (Device), Medium 13px (Desktop)"]
                       """
                    )
                 ]
             ]
         ]
+
+
+      , Grid.cell [ Grid.size Grid.All 12 ]
+        [ table []
+            [ tbody []
+                [ typoRow'
+                    ( p [ Typo.many [Typo.left, Typo.titleColorContrast] ] [ text "Left align" ]
+                    , """
+                       p [ Typo.many [Typo.left, Typo.titleColorContrast] ]
+                         [ text "Left align" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ Typo.many [Typo.body2ColorContrast,  Typo.center] ] [ text "Center align" ]
+                    , """
+                       p [ Typo.many [Typo.body2ColorContrast,  Typo.center] ]
+                         [ text "Center align" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ Typo.many [Typo.caption, Typo.right] ] [ text "Right align" ]
+                    , """
+                       p [ Typo.many [Typo.caption, Typo.right] ]
+                         [ text "Right align" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ class Typo.justify ] [ text "Justified" ]
+                    , """
+                       p [ class Typo.justify ]
+                         [ text "Justified" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ class Typo.capitalize ] [ text "capitalized" ]
+                    , """
+                       p [ class Typo.capitalize ]
+                         [ text "capitalized" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ class Typo.lowercase ] [ text "LOWERCASE" ]
+                    , """
+                       p [ class Typo.lowercase ]
+                         [ text "LOWERCASE" ]
+                       """
+                    )
+
+                , typoRow'
+                    ( p [ class Typo.uppercase ] [ text "uppercase" ]
+                    , """
+                       p [ class Typo.uppercase ]
+                         [ text "uppercase" ]
+                       """
+                    )
+                ]
+            ]
+        ]
       ]
+
+
   ]
   |> Page.body2 "Typography" srcUrl intro references
 
 
 intro : Html m
 intro =
-  Page.fromMDL "https://www.getmdl.io/components/index.html#Typography-section" """
-> ...
+  Page.fromMDL "https://github.com/google/material-design-lite/tree/mdl-1.x/src/typography#introduction" """
+> The Material Design Lite (MDL) typography component is a comprehensive approach
+> to standardizing the use of typefaces in applications and page displays. MDL
+> typography elements are intended to replace the myriad fonts used by developers
+> (which vary significantly in appearance) and provide a robust, uniform library
+> of text styles from which developers can choose.
+>
+> The "Roboto" typeface is the standard for MDL display; it can easily be
+> integrated into a web page using the CSS3 @font-face rule. However, Roboto is
+> most simply accessed and included using a single standard HTML <link> element,
+> which can be obtained at this Google fonts page.
+>
+> Because of the many possible variations in font display characteristics in HTML
+> and CSS, MDL typography aims to provide simple and intuitive styles that use the
+> Roboto font and produce visually attractive and internally consistent text
+> results. See the typography component's [Material Design specifications](https://material.google.com/style/typography.html) page for
+> details.
 """
 
 
@@ -200,6 +294,6 @@ srcUrl =
 references : List (String, String)
 references =
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Typography"
-  , Page.mds "https://www.google.com/design/spec/components/Typography.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#Typography"
+  , Page.mds "https://material.google.com/style/typography.html"
+  , Page.mdl "https://github.com/google/material-design-lite/tree/mdl-1.x/src/typography#introduction"
   ]

--- a/demo/Demo/Typography.elm
+++ b/demo/Demo/Typography.elm
@@ -5,7 +5,9 @@ import Html exposing (..)
 import Html.Attributes as Html exposing (class, classList)
 
 import Material.Typography as Typo
+import Material.Options as Options
 import Material
+import Material.Options exposing (styled)
 import Material.Grid as Grid
 
 import Demo.Page as Page
@@ -90,7 +92,8 @@ view model  =
           [ p [] [text "Example use: "]
           , Code.code """
                        import Material.Typography as Typo
-                       import Html.Attributes exposing (class)
+                       import Material.Options as Options
+                       import Html exposing (p)
                        """
           ]
 
@@ -98,97 +101,109 @@ view model  =
         [ table []
             [ tbody []
                 [ typoRow
-                   ( p [ class Typo.display4 ] [text "Light 112px"]
+                   ( Options.styled p [ Typo.display4 ] [text "Light 112px"]
                    , """
-                      p [ class Typo.display4 ]
+                      Options.styled p
+                        [ Typo.display4 ]
                         [ text "Light 112px" ]
                       """
                    )
 
                 , typoRow
-                      ( p [ class Typo.display3 ] [text "Regular 56px" ]
+                      ( Options.styled p [ Typo.display3 ] [text "Regular 56px" ]
                       , """
-                        p [ class Typo.display3 ]
+                        Options.styled p
+                          [ Typo.display3 ]
                           [ text "Regular 56px" ]
                         """
                       )
 
                 , typoRow
-                      ( p [ class Typo.display2 ] [text "Regular 45px"]
+                      ( Options.styled p [ Typo.display2 ] [text "Regular 45px"]
                       , """
-                        p [ class Typo.display2 ]
+                        Options.styled p
+                          [ Typo.display2 ]
                           [ text "Regular 45px" ]
                         """
                       )
 
                  , typoRow
-                   ( p [ class Typo.display1 ] [text "Regular 34px"]
+                   ( Options.styled p [ Typo.display1 ] [text "Regular 34px"]
                    , """
-                      p [ class Typo.display1 ]
+                      Options.styled p
+                        [ Typo.display1 ]
                         [ text "Regular 34px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.headline ] [text "Regular 24px"]
+                   ( Options.styled p [ Typo.headline ] [text "Regular 24px"]
                    , """
-                      p [ class Typo.headline ]
+                      Options.styled p
+                        [ Typo.headline ]
                         [ text "Regular 24px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.title ] [text "Medium 20px"]
+                   ( Options.styled p [ Typo.title ] [text "Medium 20px"]
                    , """
-                      p [ class Typo.title ]
+                      Options.styled p
+                        [ Typo.title ]
                         [ text "Medium 20px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
+                   ( Options.styled p [ Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
                    , """
-                      p [ class Typo.subheading ]
+                      Options.styled p
+                        [ Typo.subheading ]
                         [ text "Regular 16px (Device), Regular 15px (Desktop)" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   ( Options.styled p [ Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
-                      p [ class Typo.body2 ]
+                      Options.styled p
+                        [ Typo.body2 ]
                         [ text "Medium 14px (Device), Medium 13px (Desktop)" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
+                   ( Options.styled p [ Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
                    , """
-                      p [ class Typo.body1 ]
+                      Options.styled p
+                        [ Typo.body1 ]
                         [ text "Regular 14px (Device), Regular 13px (Desktop)" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.caption ] [text "Regular 12px"]
+                   ( Options.styled p [ Typo.caption ] [text "Regular 12px"]
                    , """
-                      p [ class Typo.caption ]
+                      Options.styled p
+                        [ Typo.caption ]
                         [ text "Regular 12px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.button ] [text "Medium (All Caps) 14px"]
+                   ( Options.styled p [ Typo.button ] [text "Medium (All Caps) 14px"]
                    , """
-                      p [ class Typo.button ]
+                      Options.styled p
+                        [ Typo.button ]
                         [ text "Medium (All Caps) 14px" ]
                       """
                    )
 
                  , typoRow
-                   ( p [ class Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                   ( Options.styled p [ Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
-                      p [ class Typo.menu ]
+                      Options.styled p
+                        [ Typo.menu ]
                         [ text "Medium 14px (Device), Medium 13px (Desktop)" ]
                       """
                    )
@@ -201,57 +216,64 @@ view model  =
         [ table []
             [ tbody []
                 [ typoRow'
-                    ( p [ Typo.many [Typo.left, Typo.titleColorContrast] ] [ text "Left align" ]
+                    ( Options.styled p [ Typo.left, Typo.titleColorContrast ] [ text "Left align" ]
                     , """
-                       p [ Typo.many [Typo.left, Typo.titleColorContrast] ]
+                       Options.styled p
+                         [ Typo.left, Typo.titleColorContrast ]
                          [ text "Left align" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ Typo.many [Typo.body2ColorContrast, Typo.center] ] [ text "Center align" ]
+                    ( Options.styled p [ Typo.body2ColorContrast, Typo.center ] [ text "Center align" ]
                     , """
-                       p [ Typo.many [Typo.body2ColorContrast, Typo.center] ]
+                       Options.styled p
+                         [ Typo.body2ColorContrast, Typo.center ]
                          [ text "Center align" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ Typo.many [Typo.caption, Typo.right] ] [ text "Right align" ]
+                    ( Options.styled p [ Typo.caption, Typo.right ] [ text "Right align" ]
                     , """
-                       p [ Typo.many [Typo.caption, Typo.right] ]
+                       Options.styled p
+                         [ Typo.caption, Typo.right ]
                          [ text "Right align" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ Typo.many [Typo.justify, Typo.subheadingColorContrast] ] [ text "Justified" ]
+                    ( Options.styled p [ Typo.justify, Typo.subheadingColorContrast ] [ text "Justified" ]
                     , """
-                       p [ Typo.many [Typo.justify, Typo.subheadingColorContrast] ]
+                       Options.styled p
+                         [ Typo.justify, Typo.subheadingColorContrast ]
                          [ text "Justified" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ class Typo.capitalize ] [ text "capitalized" ]
+                    ( Options.styled p [ Typo.capitalize ] [ text "capitalized" ]
                     , """
-                       p [ class Typo.capitalize ]
+                       Options.styled p
+                         [ Typo.capitalize ]
                          [ text "capitalized" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ class Typo.lowercase ] [ text "LOWERCASE" ]
+                    ( Options.styled p [ Typo.lowercase ] [ text "LOWERCASE" ]
                     , """
-                       p [ class Typo.lowercase ]
+                       Options.styled p
+                         [ Typo.lowercase ]
                          [ text "LOWERCASE" ]
                        """
                     )
 
                 , typoRow'
-                    ( p [ class Typo.uppercase ] [ text "uppercase" ]
+                    ( Options.styled p [ Typo.uppercase ] [ text "uppercase" ]
                     , """
-                       p [ class Typo.uppercase ]
+                       Options.styled p
+                         [ Typo.uppercase ]
                          [ text "uppercase" ]
                        """
                     )

--- a/demo/Demo/Typography.elm
+++ b/demo/Demo/Typography.elm
@@ -90,6 +90,7 @@ view model  =
           [ p [] [text "Example use: "]
           , Code.code """
                        import Material.Typography as Typo
+                       import Html.Attributes exposing (class)
                        """
           ]
 
@@ -108,7 +109,7 @@ view model  =
                       ( p [ class Typo.display3 ] [text "Regular 56px" ]
                       , """
                         p [ class Typo.display3 ]
-                          [text "Regular 56px" ]
+                          [ text "Regular 56px" ]
                         """
                       )
 
@@ -116,7 +117,7 @@ view model  =
                       ( p [ class Typo.display2 ] [text "Regular 45px"]
                       , """
                         p [ class Typo.display2 ]
-                          [text "Regular 45px"]
+                          [ text "Regular 45px" ]
                         """
                       )
 
@@ -132,7 +133,7 @@ view model  =
                    ( p [ class Typo.headline ] [text "Regular 24px"]
                    , """
                       p [ class Typo.headline ]
-                        [text "Regular 24px"]
+                        [ text "Regular 24px" ]
                       """
                    )
 
@@ -140,7 +141,7 @@ view model  =
                    ( p [ class Typo.title ] [text "Medium 20px"]
                    , """
                       p [ class Typo.title ]
-                        [text "Medium 20px"]
+                        [ text "Medium 20px" ]
                       """
                    )
 
@@ -148,7 +149,7 @@ view model  =
                    ( p [ class Typo.subheading ] [text "Regular 16px (Device), Regular 15px (Desktop)"]
                    , """
                       p [ class Typo.subheading ]
-                        [text "Regular 16px (Device), Regular 15px (Desktop)"]
+                        [ text "Regular 16px (Device), Regular 15px (Desktop)" ]
                       """
                    )
 
@@ -156,7 +157,7 @@ view model  =
                    ( p [ class Typo.body2 ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
                       p [ class Typo.body2 ]
-                        [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                        [ text "Medium 14px (Device), Medium 13px (Desktop)" ]
                       """
                    )
 
@@ -164,7 +165,7 @@ view model  =
                    ( p [ class Typo.body1 ] [text "Regular 14px (Device), Regular 13px (Desktop)"]
                    , """
                       p [ class Typo.body1 ]
-                        [text "Regular 14px (Device), Regular 13px (Desktop)"]
+                        [ text "Regular 14px (Device), Regular 13px (Desktop)" ]
                       """
                    )
 
@@ -172,7 +173,7 @@ view model  =
                    ( p [ class Typo.caption ] [text "Regular 12px"]
                    , """
                       p [ class Typo.caption ]
-                        [text "Regular 12px"]
+                        [ text "Regular 12px" ]
                       """
                    )
 
@@ -180,7 +181,7 @@ view model  =
                    ( p [ class Typo.button ] [text "Medium (All Caps) 14px"]
                    , """
                       p [ class Typo.button ]
-                        [text "Medium (All Caps) 14px"]
+                        [ text "Medium (All Caps) 14px" ]
                       """
                    )
 
@@ -188,7 +189,7 @@ view model  =
                    ( p [ class Typo.menu ] [text "Medium 14px (Device), Medium 13px (Desktop)"]
                    , """
                       p [ class Typo.menu ]
-                        [text "Medium 14px (Device), Medium 13px (Desktop)"]
+                        [ text "Medium 14px (Device), Medium 13px (Desktop)" ]
                       """
                    )
                 ]
@@ -208,9 +209,9 @@ view model  =
                     )
 
                 , typoRow'
-                    ( p [ Typo.many [Typo.body2ColorContrast,  Typo.center] ] [ text "Center align" ]
+                    ( p [ Typo.many [Typo.body2ColorContrast, Typo.center] ] [ text "Center align" ]
                     , """
-                       p [ Typo.many [Typo.body2ColorContrast,  Typo.center] ]
+                       p [ Typo.many [Typo.body2ColorContrast, Typo.center] ]
                          [ text "Center align" ]
                        """
                     )
@@ -224,9 +225,9 @@ view model  =
                     )
 
                 , typoRow'
-                    ( p [ class Typo.justify ] [ text "Justified" ]
+                    ( p [ Typo.many [Typo.justify, Typo.subheadingColorContrast] ] [ text "Justified" ]
                     , """
-                       p [ class Typo.justify ]
+                       p [ Typo.many [Typo.justify, Typo.subheadingColorContrast] ]
                          [ text "Justified" ]
                        """
                     )

--- a/demo/Demo/Typography.elm
+++ b/demo/Demo/Typography.elm
@@ -2,12 +2,11 @@ module Demo.Typography exposing (..)
 
 import Platform.Cmd exposing (Cmd, none)
 import Html exposing (..)
-import Html.Attributes as Html exposing (class, classList)
+import Html.Attributes as Html
 
 import Material.Typography as Typo
 import Material.Options as Options
 import Material
-import Material.Options exposing (styled)
 import Material.Grid as Grid
 
 import Demo.Page as Page
@@ -48,15 +47,6 @@ update action model =
 
     Mdl action' ->
       Material.update Mdl action' model
-
-
-
-typoDemo : (Html m, String) -> Grid.Cell m
-typoDemo (html, code) =
-  Grid.cell [Grid.size Grid.All 4]
-    [ div [] [ html ]
-    , Code.code code
-    ]
 
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -28,6 +28,7 @@
         "Material.Tooltip",
         "Material.Toggles",
         "Material.Tabs",
+        "Material.Typography",
         "Material.Textfield"
     ],
     "dependencies": {

--- a/src/Material/Typography.elm
+++ b/src/Material/Typography.elm
@@ -26,8 +26,6 @@ module Material.Typography
     , center
     , right
     , justify
-    , many
-    , many'
     , nowrap
     , tableStriped
     )
@@ -85,14 +83,12 @@ for a live demo.
 @docs justify
 
 # Utility
-@docs many
-@docs many'
 @docs nowrap
 @docs tableStriped
 
 -}
 
-import Material.Options as Options
+import Material.Options as Options exposing (cs)
 import Html
 import Html.Attributes as Html
 
@@ -237,135 +233,135 @@ forcePreferred style =
 
 {-| Regular 34px
 -}
-display1 : String
+display1 : Options.Property c m
 display1 =
-  styleName Display1
+  cs <| styleName Display1
 
 
 {-| Display with color contrast
 -}
-display1ColorContrast : String
+display1ColorContrast : Options.Property c m
 display1ColorContrast =
-  styleName Display1
+  cs <| styleName Display1
 
 
 {-| Regular 45px
 -}
-display2 : String
+display2 : Options.Property c m
 display2 =
-  styleName Display2
+  cs <| styleName Display2
 
 
 {-| Regular 56px
 -}
-display3 : String
+display3 : Options.Property c m
 display3 =
-  styleName Display3
+  cs <| styleName Display3
 
 
 {-| Light 112px
 -}
-display4 : String
+display4 : Options.Property c m
 display4 =
-  styleName Display4
+  cs <| styleName Display4
 
 
 {-| Regular 24px
 -}
-headline : String
+headline : Options.Property c m
 headline =
-  styleName Headline
+  cs <| styleName Headline
 
 
 {-| Medium 20px
 -}
-title : String
+title : Options.Property c m
 title =
-  styleName Title
+  cs <| styleName Title
 
 
 {-| Title with color contrast
 -}
-titleColorContrast : String
+titleColorContrast : Options.Property c m
 titleColorContrast =
-  colorContrast Title
+  cs <| colorContrast Title
 
 
 {-| Regular 16px (Device), Regular 15px (Desktop)
 -}
-subheading : String
+subheading : Options.Property c m
 subheading =
-  styleName Subheading
+  cs <| styleName Subheading
 
 
 {-| Subhead with color contrast
 -}
-subheadingColorContrast : String
+subheadingColorContrast : Options.Property c m
 subheadingColorContrast =
-  colorContrast Subheading
+  cs <| colorContrast Subheading
 
 
 {-| Medium 14px (Device), Medium 13px (Desktop)
 -}
-body2 : String
+body2 : Options.Property c m
 body2 =
-  styleName Body2
+  cs <| styleName Body2
 
 
 {-| Medium 14px (Device), Medium 13px (Desktop)
 -}
-body2ForcePreferred : String
+body2ForcePreferred : Options.Property c m
 body2ForcePreferred =
-  forcePreferred Body2
+  cs <| forcePreferred Body2
 
 
 {-| Body with color contrast
 -}
-body2ColorContrast : String
+body2ColorContrast : Options.Property c m
 body2ColorContrast =
-  colorContrast Body2
+  cs <| colorContrast Body2
 
 
 {-| Regular 14px (Device), Regular 13px (Desktop)
 -}
-body1 : String
+body1 : Options.Property c m
 body1 =
-  styleName Body1
+  cs <| styleName Body1
 
 
 {-| Regular 14px (Device), Regular 13px (Desktop)
 -}
-body1ForcePreferred : String
+body1ForcePreferred : Options.Property c m
 body1ForcePreferred =
-  forcePreferred Body1
+  cs <| forcePreferred Body1
 
 
 {-| Regular 12px
 -}
-caption : String
+caption : Options.Property c m
 caption =
-  styleName Caption
+  cs <| styleName Caption
 
 
 {-| Regular 12px
 -}
-captionColorContrast : String
+captionColorContrast : Options.Property c m
 captionColorContrast =
-  colorContrast Caption
+  cs <| colorContrast Caption
 
 
 {-| Medium (All Caps) 14px
 -}
-button : String
+button : Options.Property c m
 button =
-  styleName Button
+  cs <| styleName Button
 
 
 {-| Medium 14px (Device), Medium 13px (Desktop)
 -}
-menu : String
+menu : Options.Property c m
 menu =
-  styleName Menu
+  cs <| styleName Menu
 
 
 
@@ -374,35 +370,16 @@ menu =
 
 {-| No wrap text
 -}
-nowrap : String
+nowrap : Options.Property c m
 nowrap =
-  "mdl-typography--text-nowrap"
+  cs "mdl-typography--text-nowrap"
 
 
 {-| Striped table
 -}
-tableStriped : String
+tableStriped : Options.Property c m
 tableStriped =
-  "mdl-typography--table-striped"
-
-
-{-| Utility function to combine several classes into a `Html.Attribute msg`
--}
-many : List String -> Html.Attribute msg
-many classes =
-  classes
-    |> List.map (\class -> ( class, True ))
-    |> Html.classList
-
-
-{-| Utility function to combine several classes into a `Options.Property c m`
--}
-many' : List String -> Options.Property c m
-many' classes =
-  classes
-    |> List.map (\class -> Options.cs class)
-    |> Options.many
-
+  cs "mdl-typography--table-striped"
 
 
 -- Align
@@ -410,30 +387,30 @@ many' classes =
 
 {-| Center aligned text
 -}
-center : String
+center : Options.Property c m
 center =
-  alignName Center
+  cs <| alignName Center
 
 
 {-| Left aligned text
 -}
-left : String
+left : Options.Property c m
 left =
-  alignName Left
+  cs <| alignName Left
 
 
 {-| Right aligned text
 -}
-right : String
+right : Options.Property c m
 right =
-  alignName Right
+  cs <| alignName Right
 
 
 {-| Justified text
 -}
-justify : String
+justify : Options.Property c m
 justify =
-  alignName Justify
+  cs <| alignName Justify
 
 
 
@@ -442,20 +419,20 @@ justify =
 
 {-| Capitalized text
 -}
-capitalize : String
+capitalize : Options.Property c m
 capitalize =
-  transformName Capitalize
+  cs <| transformName Capitalize
 
 
 {-| Lowercased text
 -}
-lowercase : String
+lowercase : Options.Property c m
 lowercase =
-  transformName Lowercase
+  cs <| transformName Lowercase
 
 
 {-| Uppercased text
 -}
-uppercase : String
+uppercase : Options.Property c m
 uppercase =
-  transformName Uppercase
+  cs <| transformName Uppercase

--- a/src/Material/Typography.elm
+++ b/src/Material/Typography.elm
@@ -1,4 +1,36 @@
-module Material.Typography exposing (..)
+module Material.Typography
+  exposing
+    ( display1
+    , display1ColorContrast
+    , display2
+    , display3
+    , display4
+    , body1
+    , body1ForcePreferred
+    , body2
+    , body2ForcePreferred
+    , body2ColorContrast
+    , headline
+    , subheading
+    , subheadingColorContrast
+    , caption
+    , captionColorContrast
+    , button
+    , menu
+    , title
+    , titleColorContrast
+    , capitalize
+    , lowercase
+    , uppercase
+    , left
+    , center
+    , right
+    , justify
+    , many
+    , many'
+    , nowrap
+    , tableStriped
+    )
 
 {-| From the [Material Design Lite documentation](https://github.com/google/material-design-lite/tree/mdl-1.x/src/typography#introduction):
 
@@ -20,20 +52,45 @@ module Material.Typography exposing (..)
 > details.
 
 See also the
-[Material Design Specification]([https://www.google.com/design/spec/style/typography.html).
+[Material Design Specification](https://www.google.com/design/spec/style/typography.html).
 
 Refer to [this site](http://debois.github.io/elm-mdl#/typography)
 for a live demo.
 
-@docs Model, model, Msg, update
-@docs view
+# Styles
 
-# Component support
+@docs display1, display1ColorContrast
+@docs display2
+@docs display3
+@docs display4
+@docs body1, body1ForcePreferred
+@docs body2, body2ForcePreferred, body2ColorContrast
+@docs headline
+@docs subheading, subheadingColorContrast
+@docs caption, captionColorContrast
+@docs button
+@docs menu
+@docs title
+@docs titleColorContrast
 
-@docs Container, Observer, Instance, instance, fwdTypography
+# Transforms
+@docs capitalize
+@docs lowercase
+@docs uppercase
+
+# Alignment
+@docs left
+@docs center
+@docs right
+@docs justify
+
+# Utility
+@docs many
+@docs many'
+@docs nowrap
+@docs tableStriped
+
 -}
-
--- Typography. Copy this to a file for your component, then update.
 
 import Material.Options as Options
 import Html
@@ -155,6 +212,7 @@ colorContrast style =
     Caption ->
       "mdl-typography--caption-color-contrast"
 
+    -- Should _never_ happen (Can check with Debug.crash)
     _ ->
       ""
 
@@ -168,6 +226,7 @@ forcePreferred style =
     Body2 ->
       "mdl-typography--body-2-force-preferred-font"
 
+    -- Should _never_ happen (Can check with Debug.crash)
     _ ->
       ""
 
@@ -312,6 +371,7 @@ menu =
 
 -- Utility
 
+
 {-| No wrap text
 -}
 nowrap : String
@@ -331,7 +391,7 @@ tableStriped =
 many : List String -> Html.Attribute msg
 many classes =
   classes
-    |> List.map (\ class -> (class, True))
+    |> List.map (\class -> ( class, True ))
     |> Html.classList
 
 
@@ -340,8 +400,10 @@ many classes =
 many' : List String -> Options.Property c m
 many' classes =
   classes
-    |> List.map (\ class -> Options.cs class )
+    |> List.map (\class -> Options.cs class)
     |> Options.many
+
+
 
 -- Align
 

--- a/src/Material/Typography.elm
+++ b/src/Material/Typography.elm
@@ -1,13 +1,28 @@
 module Material.Typography exposing (..)
 
-{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#Typography-section):
+{-| From the [Material Design Lite documentation](https://github.com/google/material-design-lite/tree/mdl-1.x/src/typography#introduction):
 
-> ...
+> The Material Design Lite (MDL) typography component is a comprehensive approach
+> to standardizing the use of typefaces in applications and page displays. MDL
+> typography elements are intended to replace the myriad fonts used by developers
+> (which vary significantly in appearance) and provide a robust, uniform library
+> of text styles from which developers can choose.
+>
+> The "Roboto" typeface is the standard for MDL display; it can easily be
+> integrated into a web page using the CSS3 @font-face rule. However, Roboto is
+> most simply accessed and included using a single standard HTML <link> element,
+> which can be obtained at this Google fonts page.
+>
+> Because of the many possible variations in font display characteristics in HTML
+> and CSS, MDL typography aims to provide simple and intuitive styles that use the
+> Roboto font and produce visually attractive and internally consistent text
+> results. See the typography component's [Material Design specifications](https://material.google.com/style/typography.html) page for
+> details.
 
 See also the
-[Material Design Specification]([https://www.google.com/design/spec/components/Typography.html).
+[Material Design Specification]([https://www.google.com/design/spec/style/typography.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/Typography)
+Refer to [this site](http://debois.github.io/elm-mdl#/typography)
 for a live demo.
 
 @docs Model, model, Msg, update
@@ -20,6 +35,7 @@ for a live demo.
 
 -- Typography. Copy this to a file for your component, then update.
 
+import Material.Options as Options
 import Html
 import Html.Attributes as Html
 
@@ -37,10 +53,6 @@ type TextStyle
   | Caption
   | Button
   | Menu
-
-
-
-{- This is only in MDL -}
 
 
 type TextTransform
@@ -83,16 +95,6 @@ transformName transform =
 
     Uppercase ->
       "mdl-typography--text-uppercase"
-
-
-nowrap : String
-nowrap =
-  "mdl-typography--text-nowrap"
-
-
-tableStriped : String
-tableStriped =
-  "mdl-typography--table-striped"
 
 
 styleName : TextStyle -> String
@@ -150,6 +152,9 @@ colorContrast style =
     Title ->
       "mdl-typography--title-color-contrast"
 
+    Caption ->
+      "mdl-typography--caption-color-contrast"
+
     _ ->
       ""
 
@@ -167,61 +172,228 @@ forcePreferred style =
       ""
 
 
-display1 : Html.Attribute msg
+
+-- Styles
+
+
+{-| Regular 34px
+-}
+display1 : String
 display1 =
-  Html.class <| styleName Display1
+  styleName Display1
 
 
-display2 : Html.Attribute msg
+{-| Display with color contrast
+-}
+display1ColorContrast : String
+display1ColorContrast =
+  styleName Display1
+
+
+{-| Regular 45px
+-}
+display2 : String
 display2 =
-  Html.class <| styleName Display2
+  styleName Display2
 
 
-display3 : Html.Attribute msg
+{-| Regular 56px
+-}
+display3 : String
 display3 =
-  Html.class <| styleName Display3
+  styleName Display3
 
 
-display4 : Html.Attribute msg
+{-| Light 112px
+-}
+display4 : String
 display4 =
-  Html.class <| styleName Display4
+  styleName Display4
 
 
-headline : Html.Attribute msg
+{-| Regular 24px
+-}
+headline : String
 headline =
-  Html.class <| styleName Headline
+  styleName Headline
 
 
-title : Html.Attribute msg
+{-| Medium 20px
+-}
+title : String
 title =
-  Html.class <| styleName Title
+  styleName Title
 
 
-subheading : Html.Attribute msg
+{-| Title with color contrast
+-}
+titleColorContrast : String
+titleColorContrast =
+  colorContrast Title
+
+
+{-| Regular 16px (Device), Regular 15px (Desktop)
+-}
+subheading : String
 subheading =
-  Html.class <| styleName Subheading
+  styleName Subheading
 
 
-body2 : Html.Attribute msg
+{-| Subhead with color contrast
+-}
+subheadingColorContrast : String
+subheadingColorContrast =
+  colorContrast Subheading
+
+
+{-| Medium 14px (Device), Medium 13px (Desktop)
+-}
+body2 : String
 body2 =
-  Html.class <| styleName Body2
+  styleName Body2
 
 
-body1 : Html.Attribute msg
+{-| Medium 14px (Device), Medium 13px (Desktop)
+-}
+body2ForcePreferred : String
+body2ForcePreferred =
+  forcePreferred Body2
+
+
+{-| Body with color contrast
+-}
+body2ColorContrast : String
+body2ColorContrast =
+  colorContrast Body2
+
+
+{-| Regular 14px (Device), Regular 13px (Desktop)
+-}
+body1 : String
 body1 =
-  Html.class <| styleName Body1
+  styleName Body1
 
 
-caption : Html.Attribute msg
+{-| Regular 14px (Device), Regular 13px (Desktop)
+-}
+body1ForcePreferred : String
+body1ForcePreferred =
+  forcePreferred Body1
+
+
+{-| Regular 12px
+-}
+caption : String
 caption =
-  Html.class <| styleName Caption
+  styleName Caption
 
 
-button : Html.Attribute msg
+{-| Regular 12px
+-}
+captionColorContrast : String
+captionColorContrast =
+  colorContrast Caption
+
+
+{-| Medium (All Caps) 14px
+-}
+button : String
 button =
-  Html.class <| styleName Button
+  styleName Button
 
 
-menu : Html.Attribute msg
+{-| Medium 14px (Device), Medium 13px (Desktop)
+-}
+menu : String
 menu =
-  Html.class <| styleName Menu
+  styleName Menu
+
+
+
+-- Utility
+
+{-| No wrap text
+-}
+nowrap : String
+nowrap =
+  "mdl-typography--text-nowrap"
+
+
+{-| Striped table
+-}
+tableStriped : String
+tableStriped =
+  "mdl-typography--table-striped"
+
+
+{-| Utility function to combine several classes into a `Html.Attribute msg`
+-}
+many : List String -> Html.Attribute msg
+many classes =
+  classes
+    |> List.map (\ class -> (class, True))
+    |> Html.classList
+
+
+{-| Utility function to combine several classes into a `Options.Property c m`
+-}
+many' : List String -> Options.Property c m
+many' classes =
+  classes
+    |> List.map (\ class -> Options.cs class )
+    |> Options.many
+
+-- Align
+
+
+{-| Center aligned text
+-}
+center : String
+center =
+  alignName Center
+
+
+{-| Left aligned text
+-}
+left : String
+left =
+  alignName Left
+
+
+{-| Right aligned text
+-}
+right : String
+right =
+  alignName Right
+
+
+{-| Justified text
+-}
+justify : String
+justify =
+  alignName Justify
+
+
+
+-- Transform
+
+
+{-| Capitalized text
+-}
+capitalize : String
+capitalize =
+  transformName Capitalize
+
+
+{-| Lowercased text
+-}
+lowercase : String
+lowercase =
+  transformName Lowercase
+
+
+{-| Uppercased text
+-}
+uppercase : String
+uppercase =
+  transformName Uppercase

--- a/src/Material/Typography.elm
+++ b/src/Material/Typography.elm
@@ -1,0 +1,227 @@
+module Material.Typography exposing (..)
+
+{-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#Typography-section):
+
+> ...
+
+See also the
+[Material Design Specification]([https://www.google.com/design/spec/components/Typography.html).
+
+Refer to [this site](http://debois.github.io/elm-mdl#/Typography)
+for a live demo.
+
+@docs Model, model, Msg, update
+@docs view
+
+# Component support
+
+@docs Container, Observer, Instance, instance, fwdTypography
+-}
+
+-- Typography. Copy this to a file for your component, then update.
+
+import Html
+import Html.Attributes as Html
+
+
+type TextStyle
+  = Display4
+  | Display3
+  | Display2
+  | Display1
+  | Headline
+  | Title
+  | Subheading
+  | Body2
+  | Body1
+  | Caption
+  | Button
+  | Menu
+
+
+
+{- This is only in MDL -}
+
+
+type TextTransform
+  = Capitalize
+  | Lowercase
+  | Uppercase
+
+
+type TextAlign
+  = Center
+  | Left
+  | Right
+  | Justify
+
+
+alignName : TextAlign -> String
+alignName align =
+  case align of
+    Center ->
+      "mdl-typography--text-center"
+
+    Left ->
+      "mdl-typography--text-left"
+
+    Right ->
+      "mdl-typography--text-right"
+
+    Justify ->
+      "mdl-typography--text-justify"
+
+
+transformName : TextTransform -> String
+transformName transform =
+  case transform of
+    Capitalize ->
+      "mdl-typography--text-capitalize"
+
+    Lowercase ->
+      "mdl-typography--text-lowercase"
+
+    Uppercase ->
+      "mdl-typography--text-uppercase"
+
+
+nowrap : String
+nowrap =
+  "mdl-typography--text-nowrap"
+
+
+tableStriped : String
+tableStriped =
+  "mdl-typography--table-striped"
+
+
+styleName : TextStyle -> String
+styleName style =
+  case style of
+    Display4 ->
+      "mdl-typography--display-4"
+
+    Display3 ->
+      "mdl-typography--display-3"
+
+    Display2 ->
+      "mdl-typography--display-2"
+
+    Display1 ->
+      "mdl-typography--display-1"
+
+    Headline ->
+      "mdl-typography--display-1"
+
+    Title ->
+      "mdl-typography--title"
+
+    Subheading ->
+      "mdl-typography--subhead"
+
+    Body2 ->
+      "mdl-typography--body-2"
+
+    Body1 ->
+      "mdl-typography--body-1"
+
+    Caption ->
+      "mdl-typography--caption"
+
+    Button ->
+      "mdl-typography--button"
+
+    Menu ->
+      "mdl-typography--menu"
+
+
+colorContrast : TextStyle -> String
+colorContrast style =
+  case style of
+    Display1 ->
+      "mdl-typography--display-1-color-contrast"
+
+    Body2 ->
+      "mdl-typography--body-2-color-contrast"
+
+    Subheading ->
+      "mdl-typography--subhead-color-contrast"
+
+    Title ->
+      "mdl-typography--title-color-contrast"
+
+    _ ->
+      ""
+
+
+forcePreferred : TextStyle -> String
+forcePreferred style =
+  case style of
+    Body1 ->
+      "mdl-typography--body-1-force-preferred-font"
+
+    Body2 ->
+      "mdl-typography--body-2-force-preferred-font"
+
+    _ ->
+      ""
+
+
+display1 : Html.Attribute msg
+display1 =
+  Html.class <| styleName Display1
+
+
+display2 : Html.Attribute msg
+display2 =
+  Html.class <| styleName Display2
+
+
+display3 : Html.Attribute msg
+display3 =
+  Html.class <| styleName Display3
+
+
+display4 : Html.Attribute msg
+display4 =
+  Html.class <| styleName Display4
+
+
+headline : Html.Attribute msg
+headline =
+  Html.class <| styleName Headline
+
+
+title : Html.Attribute msg
+title =
+  Html.class <| styleName Title
+
+
+subheading : Html.Attribute msg
+subheading =
+  Html.class <| styleName Subheading
+
+
+body2 : Html.Attribute msg
+body2 =
+  Html.class <| styleName Body2
+
+
+body1 : Html.Attribute msg
+body1 =
+  Html.class <| styleName Body1
+
+
+caption : Html.Attribute msg
+caption =
+  Html.class <| styleName Caption
+
+
+button : Html.Attribute msg
+button =
+  Html.class <| styleName Button
+
+
+menu : Html.Attribute msg
+menu =
+  Html.class <| styleName Menu


### PR DESCRIPTION
Initial implementation of `Typography` module to resolve #18.

Right now it simply returns the class strings, that the user must manually apply to with a `Html.class`. 

Example use: 

```elm 
import Material.Typography as Typo
import Html exposing (p)
import Html.Attributes exposing (class)

example : Html msg 
example = p [ class Typo.display4 ] 
            [text "Light 112px"]
```

There is also an utility to combine many classes

```elm
import Material.Typography as Typo
import Html exposing (p)
example : Html msg 
example = p [ Typo.many [Typo.left, Typo.titleColorContrast] ] 
            [ text "Left align" ]
```  

I wish `Html.class` would work like `Material.Options.cs` allowing you to have multiple `class` declarations in your properties. This would allow for simpler API.  

Open to feedback and suggestions.
