### PR TITLE
Textfield extra attributes

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -10,7 +10,10 @@ import Material.Options as Options
 import Material
 
 import Demo.Page as Page
+import String
 
+import Material.Slider as Slider
+import Material.Typography as Typo
 
 -- MODEL
 
@@ -20,6 +23,8 @@ type alias Model =
   , str0 : String
   , str3 : String
   , str4 : String
+  , str6 : String
+  , length : Float 
   }
 
 
@@ -29,6 +34,8 @@ model =
   , str0 = ""
   , str3 = ""
   , str4 = ""
+  , str6 = ""
+  , length = 50
   }
 
 
@@ -40,8 +47,10 @@ type Msg
   | Upd0 String 
   | Upd3 String
   | Upd4 String
+  | Upd6 String
   | Blur (List Int)
   | Focus (List Int)
+  | Slider Float 
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -58,6 +67,12 @@ update action model =
   
     Upd4 str -> 
       ( { model | str4 = str }, Cmd.none )
+      
+    Upd6 str -> 
+      ( { model | str6 = str }, Cmd.none )
+
+    Slider value ->
+        ( { model | length = value }, Cmd.none)
 
     Blur idx ->
       ( model, Cmd.none )
@@ -125,19 +140,50 @@ view model =
       , Textfield.onBlur (Blur [5])
       ]
   , Textfield.render MDL [6] model.mdl
-      [ Textfield.label "Default multiline textfield (50 char limit)"
+      [ Textfield.label "Default multiline textfield"
       , Textfield.textarea
-      , Textfield.autofocus
-      , Textfield.maxlength 50
-      , Textfield.onBlur (Blur [6])
-      , Textfield.onFocus (Focus [6])
       ]
+
   , Textfield.render MDL [7] model.mdl
       [ Textfield.label "Multiline with 6 rows"
       , Textfield.floatingLabel
       , Textfield.textarea
       , Textfield.rows 6
       ]
+
+  , Html.div [] 
+    [ Textfield.render MDL [8] model.mdl
+        [ Textfield.label ("Multiline textfield (" ++ 
+                            (toString (String.length model.str6)) 
+                            ++ " of " ++ (toString (truncate model.length)) 
+                            ++ " char limit)")
+        , Textfield.onInput Upd6
+        , Textfield.textarea
+
+        , Textfield.maxlength (truncate model.length)
+
+        , Textfield.autofocus
+
+        , Textfield.floatingLabel
+        
+        , Textfield.onBlur (Blur [8])
+        , Textfield.onFocus (Focus [8])
+        ]
+    , Options.styled Html.p 
+        [ Options.css "width" "80%" ] 
+        [ Options.styled Html.span
+          [ Typo.caption ]
+          [ Html.text "Drag to change the maxlength" ]
+        , Slider.view
+            [ Slider.onChange Slider
+            , Slider.value model.length
+            , Slider.max 200
+            , Slider.min 50
+            , Slider.step 1
+            ]
+        ]
+    ]
+
   ]
   |> List.map (\c -> 
       cell 
@@ -171,9 +217,6 @@ intro =
 > text field, and may be initially or programmatically disabled. There are three
 > main types of text fields in the text field component, each with its own basic
 > coding requirements. The types are single-line, multi-line, and expandable.
-
-This implementation provides only single-line.
-
 """
 
 srcUrl : String

--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -40,6 +40,8 @@ type Msg
   | Upd0 String 
   | Upd3 String
   | Upd4 String
+  | Blur (List Int)
+  | Focus (List Int)
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -56,6 +58,12 @@ update action model =
   
     Upd4 str -> 
       ( { model | str4 = str }, Cmd.none )
+
+    Blur idx ->
+      ( model, Cmd.none )
+
+    Focus idx ->
+      ( model, Cmd.none )
 
 
 -- VIEW
@@ -113,12 +121,16 @@ view model =
       [ Textfield.label "Enter password"
       , Textfield.floatingLabel
       , Textfield.password
+      , Textfield.onFocus (Focus [5])
+      , Textfield.onBlur (Blur [5])
       ]
   , Textfield.render MDL [6] model.mdl
-      [ Textfield.label "Default multiline textfield (180 char limit)"
+      [ Textfield.label "Default multiline textfield (50 char limit)"
       , Textfield.textarea
       , Textfield.autofocus
-      , Textfield.maxlength 180
+      , Textfield.maxlength 50
+      , Textfield.onBlur (Blur [6])
+      , Textfield.onFocus (Focus [6])
       ]
   , Textfield.render MDL [7] model.mdl
       [ Textfield.label "Multiline with 6 rows"

--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -115,8 +115,10 @@ view model =
       , Textfield.password
       ]
   , Textfield.render MDL [6] model.mdl
-      [ Textfield.label "Default multiline textfield"
+      [ Textfield.label "Default multiline textfield (180 char limit)"
       , Textfield.textarea
+      , Textfield.autofocus
+      , Textfield.maxlength 180
       ]
   , Textfield.render MDL [7] model.mdl
       [ Textfield.label "Multiline with 6 rows"

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -282,7 +282,6 @@ type Msg
   = Blur
   | Focus
   | Input String
-  | NoOp
 
 
 {-| Component update.
@@ -290,7 +289,6 @@ type Msg
 update : Msg -> Model -> Model
 update action model =
   case action of
-    NoOp -> model
     Input str -> 
       { model | value = str }
       

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -35,8 +35,6 @@ Refer to
 [this site](https://debois.github.io/elm-mdl/#/textfields)
 for a live demo.
  
-This implementation provides only single-line and password.
-
 # Component render
 @docs render
 

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -4,6 +4,8 @@ module Material.Textfield exposing
   , Msg, Model, defaultModel, update, view
   , render
   , text', textarea, rows, cols
+  , autofocus
+  , maxlength
   )
 
 {-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#textfields-section):
@@ -41,6 +43,7 @@ This implementation provides only single-line and password.
   
 # Appearance
 @docs label, floatingLabel, error, disabled, rows, cols
+@docs autofocus, maxlength
 
 # Type 
 @docs password, textarea, text', onInput
@@ -79,6 +82,8 @@ type alias Config m =
   , kind : Kind
   , rows : Maybe Int
   , cols : Maybe Int
+  , autofocus : Bool
+  , maxlength : Maybe Int
   }
 
 
@@ -93,6 +98,8 @@ defaultConfig =
   , onInput = Nothing
   , rows = Nothing
   , cols = Nothing
+  , autofocus = False
+  , maxlength = Nothing
   }
 
 
@@ -131,6 +138,22 @@ value : String -> Property m
 value str = 
   Options.set
     (\config -> { config | value = Just str })
+
+
+{-| Specifies that the input should automatically get focus when the page loads
+-}
+autofocus : Property m
+autofocus =
+  Options.set
+    (\config -> { config | autofocus = True })
+
+
+{-| Specifies the maximum number of characters allowed in the input
+-}
+maxlength : Int -> Property m
+maxlength v =
+  Options.set
+    (\config -> { config | maxlength = Just v })
 
 
 {-| Disable the textfield input
@@ -285,6 +308,12 @@ view lift model options =
                ++ (case config.cols of
                        Just c -> [Html.Attributes.cols c]
                        Nothing -> [])
+
+    maxlength =
+      case config.maxlength of
+        Just val -> [Html.Attributes.maxlength val]
+        Nothing -> []
+
   in
     Options.apply summary div
       [ cs "mdl-textfield"
@@ -309,7 +338,8 @@ view lift model options =
                 Html.Attributes.value str
               Nothing -> 
                 Html.Events.on "input" (Decoder.map (Input >> lift) targetValue)
-          ] ++ typeAttributes)
+          , Html.Attributes.autofocus config.autofocus
+          ] ++ typeAttributes ++ maxlength)
           []
       , Just <| Html.label 
           [class "mdl-textfield__label"]  


### PR DESCRIPTION
Had some time on my hands so added some attributes that were discussed in #87.

 ```elm
  , Textfield.render MDL [6] model.mdl
      [ Textfield.label "Default multiline textfield (50 char limit)"
      , Textfield.textarea
      , Textfield.autofocus -- New 
      , Textfield.maxlength 50 -- New
      , Textfield.onBlur (Blur [6]) -- New
      , Textfield.onFocus (Focus [6]) -- New
      ]

```