### PR TITLE
Add support for custom event handlers on Textfield

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -17,6 +17,7 @@ import Material.Typography as Typo
 import Demo.Code as Code
 
 import Material.Color as Color
+import Json.Decode as Decoder
 
 -- MODEL
 
@@ -55,6 +56,39 @@ type Msg
   | Upd6 String
   | SetFocus5 Bool 
   | Slider Float
+  | KeyUp KeyEvent
+
+
+{-| Selection range
+-}
+type alias Selection =
+  { start : Int
+  , end : Int
+  }
+
+
+{-| KeyEvent
+-}
+type alias KeyEvent =
+  { shift : Bool
+  , keyCode : Int
+  , selection : Selection
+  }
+
+
+selectionDecoder : Decoder.Decoder Selection
+selectionDecoder =
+  Decoder.object2 Selection
+    (Decoder.at ["target", "selectionStart"] Decoder.int)
+    (Decoder.at ["target", "selectionEnd"] Decoder.int)
+
+
+eventDecoder : Decoder.Decoder KeyEvent
+eventDecoder =
+  Decoder.object3 KeyEvent
+    (Decoder.at ["shiftKey"] Decoder.bool)
+    (Decoder.at ["keyCode"] Decoder.int)
+    selectionDecoder
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -80,7 +114,10 @@ update action model =
 
     SetFocus5 x ->
       { model | focus5 = x } ! [ Cmd.none ]
-      
+
+    KeyUp { shift, keyCode, selection } ->
+      -- TODO: Do something with the event
+      (model, Cmd.none)
 
 -- VIEW
 
@@ -213,6 +250,7 @@ view model =
         , Textfield.floatingLabel
         , Textfield.textarea
         , Textfield.rows 6
+        , Textfield.on "keyup" (Decoder.map KeyUp eventDecoder)
         ]
     , """
       Textfield.render MDL [7] model.mdl

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -78,7 +78,6 @@ import Platform.Cmd
 import Parts exposing (Indexed)
 
 import Material.Options as Options exposing (cs, css, nop, Style)
-import Dict exposing (Dict)
 
 
 -- OPTIONS
@@ -102,7 +101,7 @@ type alias Config m =
   , autofocus : Bool
   , maxlength : Maybe Int
   , style : List (Options.Style m)
-  , listeners : Dict String (Html.Attribute m)
+  , listeners : List (Html.Attribute m)
   }
 
 
@@ -120,7 +119,7 @@ defaultConfig =
   , autofocus = False
   , maxlength = Nothing
   , style = []
-  , listeners = Dict.empty
+  , listeners = []
   }
 
 
@@ -192,7 +191,7 @@ on event decoder =
     Options.set
       (\config ->
          { config |
-             listeners = (Dict.insert event (Html.Events.on event decoder) config.listeners)})
+             listeners = config.listeners ++ [(Html.Events.on event decoder)]})
 
 {-| Message to dispatch on input
 -}
@@ -353,7 +352,7 @@ view lift model options =
 
 
     listeners =
-      Dict.values config.listeners
+      config.listeners
 
     textValue =
       case config.value of

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -101,8 +101,6 @@ type alias Config m =
   , cols : Maybe Int
   , autofocus : Bool
   , maxlength : Maybe Int
-  , onBlur : Maybe (Html.Attribute m)
-  , onFocus : Maybe (Html.Attribute m)
   , style : List (Options.Style m)
   , listeners : Dict String (Html.Attribute m)
   }
@@ -121,8 +119,6 @@ defaultConfig =
   , cols = Nothing
   , autofocus = False
   , maxlength = Nothing
-  , onBlur = Nothing
-  , onFocus = Nothing
   , style = []
   , listeners = Dict.empty
   }


### PR DESCRIPTION
Resolves #130  

This also refactors the way event handlers are used internally.
Instead of adding the internal handlers on the input element.
The handlers are now added to the containing div using events that
are known to bubble (`input`, `focusin`, `focusout`)

See the demo code for an example for `keyup` event

The user event handlers are now added to the input element.

Open to feedback and suggestions on this one. 

