### PR TITLE
Extra url fixes

### DIFF
--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -30,7 +30,7 @@ See also the
 [Material Design Specification]([https://www.google.com/design/spec/components/buttons.html).
 
 Refer to 
-[this site](https://debois.github.io/elm-mdl/#/buttons) 
+[this site](https://debois.github.io/elm-mdl/#buttons) 
 for a live demo. 
 
 # Render

--- a/src/Material/Card.elm
+++ b/src/Material/Card.elm
@@ -29,7 +29,7 @@ module Material.Card
 > important factor in the overall user experience. See the card component's
 > Material Design specifications page for details.
 
-Refer to [this site](http://debois.github.io/elm-mdl/#/card)
+Refer to [this site](http://debois.github.io/elm-mdl/#cards)
 for a live demo.
 
 # Render

--- a/src/Material/Dialog.elm
+++ b/src/Material/Dialog.elm
@@ -19,7 +19,7 @@ module Material.Dialog
 > writing. For other browsers you will need to include the dialog polyfill
 > or create your own.
 
-Refer to [this site](http://debois.github.io/elm-mdl/#/dialog)
+Refer to [this site](http://debois.github.io/elm-mdl/#dialog)
 for a live demo.
 
 @docs view

--- a/src/Material/Elevation.elm
+++ b/src/Material/Elevation.elm
@@ -31,7 +31,7 @@ You are encouraged to visit the
 for details about appropriate use of shadows. 
 
 Refer to 
-[this site](https://debois.github.io/elm-mdl/#/elevation)
+[this site](https://debois.github.io/elm-mdl/#elevation)
 for a live demo. 
   
 

--- a/src/Material/Footer.elm
+++ b/src/Material/Footer.elm
@@ -52,7 +52,7 @@ module Material.Footer
 See also the
 [Material Design Specification](https://material.google.com/layout/structure.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/footer)
+Refer to [this site](http://debois.github.io/elm-mdl/#footers)
 for a live demo.
 
 # Types

--- a/src/Material/Grid.elm
+++ b/src/Material/Grid.elm
@@ -31,7 +31,7 @@ module Material.Grid exposing
 >     row.
 
 Refer to 
-[this site](https://debois.github.io/elm-mdl/#/grid)
+[this site](https://debois.github.io/elm-mdl/#grid)
 for a live demo. 
 
 Example use:

--- a/src/Material/Layout.elm
+++ b/src/Material/Layout.elm
@@ -35,6 +35,9 @@ module Material.Layout exposing
 > consistency in outward appearance and behavior while maintaining development
 > flexibility and ease of use.
 
+Refer to [this site](https://debois.github.io/elm-mdl/#layout)
+for a live demo and example code.
+
 # Subscriptions
 
 The layout needs to be initialised with and subscribe to changes in viewport

--- a/src/Material/List.elm
+++ b/src/Material/List.elm
@@ -16,7 +16,7 @@ module Material.List
 See also the
 [Material Design Specification]([https://material.google.com/components/lists.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/lists)
+Refer to [this site](http://debois.github.io/elm-mdl/#lists)
 for a live demo and example code.
 
 # List and item containers

--- a/src/Material/Menu.elm
+++ b/src/Material/Menu.elm
@@ -28,7 +28,7 @@ See also the
 [Material Design Specification]([https://www.google.com/design/spec/components/menus.html).
 
 Refer to
-[this site](https://debois.github.io/elm-mdl/#/menus)
+[this site](https://debois.github.io/elm-mdl/#menus)
 for a live demo.
 
 # Render

--- a/src/Material/Progress.elm
+++ b/src/Material/Progress.elm
@@ -21,7 +21,7 @@ module Material.Progress exposing
 > for details.
 
 Refer to
-[this site](https://debois.github.io/elm-mdl/#/loading)
+[this site](https://debois.github.io/elm-mdl/#loading)
 for a live demo.
 
 # Render

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -28,7 +28,7 @@ module Material.Slider
 See also the
 [Material Design Specification](https://material.google.com/components/sliders.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/sliders)
+Refer to [this site](http://debois.github.io/elm-mdl/#sliders)
 for a live demo.
 
 *NOTE* Currently does not work properly on [Microsoft Edge](https://github.com/google/material-design-lite/issues/1625)

--- a/src/Material/Snackbar.elm
+++ b/src/Material/Snackbar.elm
@@ -13,7 +13,7 @@ module Material.Snackbar exposing
 > example. Msgs should not be to close the snackbar. By not providing an
 > action, the snackbar becomes a __toast__ component.
 
-Refer to [this site](http://debois.github.io/elm-mdl#/snackbar)
+Refer to [this site](http://debois.github.io/elm-mdl/#snackbar)
 for a live demo. 
 
 # Generating messages

--- a/src/Material/Spinner.elm
+++ b/src/Material/Spinner.elm
@@ -28,7 +28,7 @@ module Material.Spinner exposing
 > important factor in the overall user experience.
 
 Refer to
-[this site](https://debois.github.io/elm-mdl/#/loading)
+[this site](https://debois.github.io/elm-mdl/#loading)
 for a live demo.
 
 @docs spinner, active, singleColor

--- a/src/Material/Table.elm
+++ b/src/Material/Table.elm
@@ -30,7 +30,7 @@ See also the
 [Material Design Specification]([https://www.google.com/design/spec/components/data-tables.html).
 
 Refer to
-[this this](https://debois.github.io/elm-mdl/#/tables
+[this this](https://debois.github.io/elm-mdl/#tables)
 for a live demo.
 
 # HTML

--- a/src/Material/Tabs.elm
+++ b/src/Material/Tabs.elm
@@ -36,7 +36,7 @@ module Material.Tabs
 See also the
 [Material Design Specification](https://material.google.com/components/tabs.html#tabs-usage).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/tabs)
+Refer to [this site](http://debois.github.io/elm-mdl/#tabs)
 for a live demo.
 
 # Types

--- a/src/Material/Template.elm
+++ b/src/Material/Template.elm
@@ -13,7 +13,7 @@ module Material.Template exposing
 See also the
 [Material Design Specification]([https://www.google.com/design/spec/components/TEMPLATE.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/template)
+Refer to [this site](http://debois.github.io/elm-mdl/#template)
 for a live demo.
 
 @docs Model, model, Msg, update

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -32,7 +32,7 @@ module Material.Textfield exposing
 
 
 Refer to 
-[this site](https://debois.github.io/elm-mdl/#/textfields)
+[this site](https://debois.github.io/elm-mdl/#textfields)
 for a live demo.
  
 # Component render

--- a/src/Material/Toggles.elm
+++ b/src/Material/Toggles.elm
@@ -26,7 +26,7 @@ module Material.Toggles exposing
 See also the
 [Material Design Specification](https://www.google.com/design/spec/components/selection-controls.html#).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/toggles)
+Refer to [this site](http://debois.github.io/elm-mdl/#toggles)
 for a live demo.
 
 # Render

--- a/src/Material/Tooltip.elm
+++ b/src/Material/Tooltip.elm
@@ -26,7 +26,7 @@ module Material.Tooltip
 See also the
 [Material Design Specification](https://material.google.com/components/tooltips.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/tooltips)
+Refer to [this site](http://debois.github.io/elm-mdl/#tooltips)
 for a live demo.
 
 To use a `tooltip` you have to (a) attach the mouse event listeners to the target

--- a/src/Material/Typography.elm
+++ b/src/Material/Typography.elm
@@ -46,7 +46,7 @@ module Material.Typography
 See also the
 [Material Design Specification](https://www.google.com/design/spec/style/typography.html).
 
-Refer to [this site](http://debois.github.io/elm-mdl#/typography)
+Refer to [this site](http://debois.github.io/elm-mdl/#typography)
 for a live demo.
 
 # Styles


### PR DESCRIPTION
Apparently it was not just the one that I fixed, but *all* of them were broken because the template was wrong.  Fixed them all, fixed the template, tested every-single-one, think I got them all.

Also, there is a lot of inconsistency in the Demo naming.  Some demo's are the same name as the type like Snackbar, Dialog, Grid, and more even though they show multiples, and others are like Footer/Footers, Card/Cards, etc...  Should probably be unified, I'd say to the same name as the type to make lookup and links easier.

For now, url fixes here, template too.