### PR TITLE
Fix is-focused not being triggered on Firefox

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -258,7 +258,7 @@ textfields model =
        """
     )
 
-  , ( "Multi-line textfield with character limit"
+  , ( "Multi-line textfield with character limit (focused: " ++ (toString model.focus5) ++ ")"
     , Html.div []
     [ Textfield.render MDL [8] model.mdl
         [ Textfield.label ("Multiline textfield (" ++
@@ -300,6 +300,8 @@ textfields model =
          , Textfield.maxlength (truncate model.length)
          , Textfield.autofocus
          , Textfield.floatingLabel
+         , Textfield.onFocus (SetFocus5 True)
+         , Textfield.onBlur (SetFocus5 False)
          ]
        """
     )


### PR DESCRIPTION
Unfortunately, Firefox does not support `focusin` and `focusout` events. 
This works around the issue by adding internal `focus` and `blur`
handlers on the `input` element and then dispatching user provided
`focus` and `blur` handlers in `update`.

Resolves #166 