### PR TITLE
Reference implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ CSS/JS implementation of the
 
 [![Build Status](https://travis-ci.org/debois/elm-mdl.svg?branch=master)](https://travis-ci.org/debois/elm-mdl)
 
-### Get Started 
+### Get Started
 
 Adapt
-[examples/Counter.elm](https://github.com/debois/elm-mdl/tree/master/examples) to suit your needs. 
-The 
+[examples/Counter.elm](https://github.com/debois/elm-mdl/tree/master/examples) to suit your needs.
+The
 [Live demo](https://debois.github.io/elm-mdl/) contains code samples for most components, which
-you may find helpful. 
+you may find helpful.
 
 For a long-form tutorial, you might like [@jadams](https://github.com/jadams) excellent "Introduction to elm-mdl", available as both a [daily drip video](https://www.dailydrip.com/topics/elm/drips/elm-mdl-introduction) and a very nice [writeup](https://medium.com/@dailydrip/introduction-to-using-material-design-in-elm-dc2320087410#.dodoot1wd).
 
@@ -26,47 +26,51 @@ documentation](http://package.elm-lang.org/packages/debois/elm-mdl/latest/).
 
 Ask any questions you may have on
 [stackoverflow](https://stackoverflow.com/questions/ask?tags=elm+elm-mdl)
-or on [#elm-mdl](https://elm.slack.com/messages/elm-mdl) in the elm-slack. 
+or on [#elm-mdl](https://elm.slack.com/messages/elm-mdl) in the elm-slack.
+
+### Other projects using Elm-mdl
+
+Check [reference implementations page](REFERENCE_IMPLEMENTATIONS.md) to see a list of projects that are using Elm-mdl.
 
 ### Contribute
 
-Contributions are warmly encouraged! Whether you are a newcomer to Elm or 
+Contributions are warmly encouraged! Whether you are a newcomer to Elm or
 an accomplished expert, the MDL port presents interesting challenges. Refer
 to [this page](https://github.com/debois/elm-mdl/blob/master/CONTRIBUTING.md)
-for a detailed list of possible contributions. 
+for a detailed list of possible contributions.
 
 Most importantly: Do [report
 bugs](https://github.com/debois/elm-mdl/issues/new). The elm-mdl library
 aims to provide a completely smooth experience with Material Design for elm
-developers. No bug is too small. 
+developers. No bug is too small.
 
 You may want to read the hints on how to get your issue [resolved
 quickly](https://github.com/debois/elm-mdl/blob/master/CONTRIBUTING.md#can-i-speed-up-my-issue)
-but you don't have to. 
+but you don't have to.
 
 ### Implementation
 
 MDL is implemented primarily through CSS, with a little bit of JavaScript
 adding and removing CSS classes in response to DOM events. This port
 re-implements the JavaScript parts in Elm, but relies on the CSS of MDL
-verbatim. 
+verbatim.
 
 ### Upgrading from 6.x.x
 
-The 7.0.0 release changes the required boilerplate in two aspects. 
+The 7.0.0 release changes the required boilerplate in two aspects.
 
 1. The type of elm-mdl messages should now be:
 
-        type Msg = 
+        type Msg =
           ...
           | Mdl (Material.Msg Msg)
 
 2. Dispatching elm-mdl messages should now be:
 
-        update message model = 
-          case message of 
+        update message model =
+          case message of
             ...
-            Mdl message' -> 
+            Mdl message' ->
               Material.update message' model
 
 Some components (notably menu) has changed API to varying degrees. If you run
@@ -74,4 +78,4 @@ into troubles, refer to the code samples in [the
 demo](https://debois.github.io/elm-mdl/); check out [the
 documentation](http://package.elm-lang.org/packages/debois/elm-mdl/latest/), or
 ask on [#elm-mdl in the elm-slack](https://elm.slack.com/messages/elm-mdl) for
-help in migrating. 
+help in migrating.

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,0 +1,57 @@
+# Other projects using Elm-mdl
+
+> This list is intended to show the general usage of elm-mdl, providing a reference of implementations and also better documentation on how elm-mdl is beeing used in various ways.
+
+> Do you know any projects / applications that should be added here? Submit an issue or a pull requests.
+
+## Projects using elm-mdl
+
+* Hydra frontend - Hydra frontend rewritten with UX in mind.
+  * [GitHub repository](https://github.com/domenkozar/hydra-frontend)
+  * [Live demo/site](http://hydra-frontend.domenkozar.com/)
+* Elephant-guide - A simple Webpack setup for writing Elm apps.
+  * [GitHub repository](https://github.com/IwalkAlone/elephant-guide)
+* Phoenix-Elm-Chat - Elm and Phoenix Chat Client.
+  * This is a chat application that we build out in episodes on the Elm and Elixir tracks for DailyDrip
+  * [GitHub repository](https://github.com/knewter/phoenix-elm-chat)
+  * [YouTube video](https://www.youtube.com/watch?v=PrUum0BDClE&feature=youtu.be)
+  * [Visit DailyDrip to learn more](https://www.dailydrip.com/)
+* Bloggero-elm-mdl - Bloggero -- engine for static blogs with single page interface.
+  * [GitHub repository](https://github.com/easimonenko/bloggero-elm-mdl)
+* Billbored - A billboard to post and share shit with ur friends.
+  * [GitHub repository](https://github.com/puhrez/billbored)
+* Calliope - Experimental Elm / Electron App, embedding ACE Editor.
+  * [GitHub repository](https://github.com/RobertWalter83/calliope)
+* Lifetrack - A SaaS lifelogging/journal tool for tracking and analyzing life metrics.
+  * [GitHub repository](https://github.com/demsullivan/lifetrack)
+* Midwife-emr-internal-docs - Midwife-EMR Documentation as presented from within the application.
+  * [GitHub repository](https://github.com/kbsymanz/midwife-emr-internal-docs)
+* Smugglers - The frontend for smuggle.rs.
+  * Has a live site - not sure what this is, but seems to have a lot of elm-mdl code.
+  * [GitHub repository](https://github.com/dgonyeo/smugglers)
+* Force gravity - Small two player app written entirely in Elm.
+  * [GitHub repository](https://github.com/stanton-gary/gravity)
+* Starcity Web - This is the main web application for Starcity.
+  * [GitHub repository](https://github.com/starcity-properties/starcity-web)
+* NDC Oslo 2016 video listing - Scripts and viewer to facilitate better navigation to NDC Oslo 2016 videos.
+  * Will be updated to use Lists instead of table
+  * [GitHub repository](https://github.com/hakonrossebo/ndc-oslo2016-video-listing)
+  * [Live demo/site](https://hakonrossebo.github.io/ndc-oslo2016-video-listing/)
+* Elm-BMI - BMI Calculator written in Elm.
+  * [GitHub repository](https://github.com/uehaj/elm-bmi)
+  * [Live demo/site](https://uehaj.github.io/elm-bmi/)
+
+
+
+
+
+
+
+*Disclaimer - elm-mdl does not endorse or suggest that these projects are "best practice". They are only listed here as a reference.*
+
+### List item template
+* Name - Description.
+  * Comment
+  * [GitHub repository](link)
+  * [Live demo/site](link)
+

--- a/src/Material/Layout.elm
+++ b/src/Material/Layout.elm
@@ -461,20 +461,20 @@ onSelectTab f =
 
 {-| Push subsequent elements in header row or drawer column to the right/bottom.
 -}
-spacer : (Html m)
+spacer : Html m
 spacer = div [class "mdl-layout-spacer"] []
 
 
 {-| Title in header row or drawer.
 -}
-title : List (Property m) -> List (Html m) -> Html m
+title : List (Options.Property c m) -> List (Html m) -> Html m
 title styles = 
   Options.span (cs "mdl-layout__title" :: styles) 
 
 
 {-| Container for links.
 -}
-navigation : List (Style m) -> List (Html m) -> Html m
+navigation : List (Options.Property c m) -> List (Html m) -> Html m
 navigation styles contents =
   nav [class "mdl-navigation"] contents
 
@@ -513,7 +513,7 @@ link styles contents =
 
 {-| Header row. 
 -}
-row : List (Property m) -> List (Html m) -> Html m
+row : List (Options.Property c m) -> List (Html m) -> Html m
 row styles = 
   Options.div (cs "mdl-layout__header-row" :: styles) 
 


### PR DESCRIPTION
This is the initial list I've found just by searching. We may need some kind of quality check to see if these are valid implementations. Not sure if we should call this reference implementations or something else. I added a link from the main readme.

Note - I recently set my editor to remove trailing whitespaces - that seems to be the reason why there are so many lines are changed in the readme.md file. I can revert this if this is a problem.