### PR TITLE
Temporary fix for #166

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -254,7 +254,7 @@ textfields model =
        """
     )
 
-  , ( "Multi-line textfield with character limit"
+  , ( "Multi-line textfield with character limit (focused: " ++ (toString model.focus5) ++ ")"
     , Html.div []
     [ Textfield.render Mdl [8] model.mdl
         [ Textfield.label ("Multiline textfield (" ++

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -190,6 +190,7 @@ on event decoder =
       (\config ->
          { config |
              listeners = config.listeners ++ [(Html.Events.on event decoder)]})
+             
 
 {-| Message to dispatch on input
 -}
@@ -202,14 +203,14 @@ onInput f =
 -}
 onBlur : m -> Property m
 onBlur f =
-  on "blur" (Decoder.succeed f)
+  on "focusout" (Decoder.succeed f)
 
 
 {-| The `focus` event occurs when the input gets focus.
 -}
 onFocus : m -> Property m
 onFocus f =
-  on "focus" (Decoder.succeed f)
+  on "focusin" (Decoder.succeed f)
 
 
 {-| Set properties on the actual `input` element in the Textfield.
@@ -378,9 +379,7 @@ view lift model options =
       , if config.disabled then cs "is-disabled" else nop
       ]
       ( List.filterMap identity 
-          ([ Just <| Html.Events.on "focusin" (Decoder.succeed (lift Focus))
-           , Just <| Html.Events.on "focusout" (Decoder.succeed (lift Blur))
-           , defaultInput
+          ([ defaultInput
            ])
       )
       [ Options.styled' elementFunction
@@ -390,6 +389,8 @@ view lift model options =
           ]
           ([ Html.Attributes.disabled config.disabled 
            , Html.Attributes.autofocus config.autofocus
+           , Html.Events.on "focus" (Decoder.succeed (lift Focus))
+           , Html.Events.on "blur" (Decoder.succeed (lift Blur))
            ] ++ textValue ++ typeAttributes ++ maxlength ++ listeners)
           []
       , Html.label 


### PR DESCRIPTION
This will resolve #166 temporarily but it will also break #87 `onBlur` and `onFocus` custom handlers
on Firefox.

Firefox does not support `focusin` and `focusout` events currently.