### PR TITLE
Add support for expandable textfields

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -224,6 +224,22 @@ textfields model =
         ]
        """
     )
+  , ( "Expandable textfield"
+    , Textfield.render Mdl [11] model.mdl
+        [ Textfield.label "Expandable"
+        , Textfield.floatingLabel
+        , Textfield.expandable "expandable-1"
+        , Textfield.expandableIcon "search"
+        ]
+    , """
+      Textfield.render Mdl [11] model.mdl
+        [ Textfield.label "Expandable"
+        , Textfield.floatingLabel
+        , Textfield.expandable "expandable-1"
+        , Textfield.expandableIcon "search"
+        ]
+       """
+    )
   , ( "Multi-line textfield"
     , Textfield.render Mdl [6] model.mdl
         [ Textfield.label "Default multiline textfield"

--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -229,24 +229,14 @@ textfields model =
     , Textfield.render Mdl [11] model.mdl
         [ Textfield.label "Expandable"
         , Textfield.floatingLabel
-        -- NOTE: The id's must match
-        -- between Html.Attributes.id and Textfield.expandable
-        , Options.inner
-            [ Options.attribute <| Html.Attributes.id "expandable-1"
-            ]
-        , Textfield.expandable "expandable-1"
+        , Textfield.expandable "id-of-expandable-1"
         , Textfield.expandableIcon "search"
         ]
     , """
       Textfield.render Mdl [11] model.mdl
         [ Textfield.label "Expandable"
         , Textfield.floatingLabel
-        -- NOTE: The id's must match
-        -- between Html.Attributes.id and Textfield.expandable
-        , Options.inner
-            [ Options.attribute <| Html.Attributes.id "expandable-1"
-            ]
-        , Textfield.expandable "expandable-1"
+        , Textfield.expandable "id-of-expandable-1"
         , Textfield.expandableIcon "search"
         ]
        """

--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -1,6 +1,7 @@
 module Demo.Textfields exposing (model, Model, update, view, Msg)
 
 import Html exposing (..)
+import Html.Attributes
 import Platform.Cmd exposing (Cmd)
 import Regex
 import Json.Decode as Decoder
@@ -228,6 +229,11 @@ textfields model =
     , Textfield.render Mdl [11] model.mdl
         [ Textfield.label "Expandable"
         , Textfield.floatingLabel
+        -- NOTE: The id's must match
+        -- between Html.Attributes.id and Textfield.expandable
+        , Options.inner
+            [ Options.attribute <| Html.Attributes.id "expandable-1"
+            ]
         , Textfield.expandable "expandable-1"
         , Textfield.expandableIcon "search"
         ]
@@ -235,6 +241,11 @@ textfields model =
       Textfield.render Mdl [11] model.mdl
         [ Textfield.label "Expandable"
         , Textfield.floatingLabel
+        -- NOTE: The id's must match
+        -- between Html.Attributes.id and Textfield.expandable
+        , Options.inner
+            [ Options.attribute <| Html.Attributes.id "expandable-1"
+            ]
         , Textfield.expandable "expandable-1"
         , Textfield.expandableIcon "search"
         ]

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -156,8 +156,8 @@ floatingLabel =
 of the element as parameter as this is currently required.
 
 **NOTE:** When manually setting the **id** of the `input` element using
-`Textfield.style` or `Options.inner` then the `expandable` **id** should match
-the `input` *id*.
+`Options.inner` then the `expandable` **id** must match
+the `input` **id**.
 -}
 expandable : String -> Property m
 expandable id =

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -429,10 +429,10 @@ view lift model options =
         Nothing -> []
         Just id -> [ Html.Attributes.for id ]
 
-    inputId =
+    expandableId =
       case config.expandable of
-        Nothing -> []
-        Just id -> [ Html.Attributes.id id ]
+        Nothing -> Options.nop
+        Just id -> Internal.attribute <| Html.Attributes.id id
 
     expHolder =
       case config.expandable of
@@ -482,11 +482,12 @@ view lift model options =
              -}
           , Internal.attribute <| Html.Events.on "focus" (Decoder.succeed (lift Focus))
           , Internal.attribute <| Html.Events.on "blur" (Decoder.succeed (lift Blur))
+          , expandableId
           , Options.many config.inner
           ]
           ([ Html.Attributes.disabled config.disabled 
            , Html.Attributes.autofocus config.autofocus
-           ] ++ textValue ++ typeAttributes ++ maxlength ++ listeners ++ inputId)
+           ] ++ textValue ++ typeAttributes ++ maxlength ++ listeners)
           []
       , Html.label 
           ([class "mdl-textfield__label"] ++ labelFor)


### PR DESCRIPTION
Initial support to resolve #198.  

Currently requires user to provide ID for the element as a parameter to `Textfield.expandable` for example `Textfield.expandable "expandable-textfield-id"`. This allows the implementation to stay extremely simple and not require any sort of JavaScript or other hacks to achieve the necessary functionality.

