### PR TITLE
Add support for id and inner attributes

### DIFF
--- a/src/Material/Options.elm
+++ b/src/Material/Options.elm
@@ -4,6 +4,8 @@ module Material.Options exposing
   , when, maybe, disabled
   , apply, styled, styled', stylesheet
   , Style, div, span, img, attribute, center, scrim
+  , id
+  , inner
   )
 
 
@@ -47,7 +49,7 @@ applying MDL typography or color to standard elements.
 @docs stylesheet
 
 ## Attributes
-@docs attribute
+@docs attribute, id, inner
 @docs center, scrim, disabled
 
 # Internal
@@ -322,3 +324,26 @@ depend on the underlying image. `0.6` works well often.
 scrim : Float -> Property c m
 scrim opacity = 
   css "background" <| "linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, " ++ toString opacity ++ "))" 
+
+
+{-| Sets the id attribute
+-}
+id : String -> Property c m
+id =
+  Attribute << Html.Attributes.id
+
+
+{-| Sets attributes on the inner element for components that support it.
+For example `Textfield`:
+
+    Textfield.render ...
+      [ ...
+      , Options.inner
+          [ Options.id "id-of-the-input"
+          ]
+      ]
+
+-}
+inner : List (Property c m) -> Property { a | inner : List (Property c m) } m
+inner options =
+  set (\c -> { c | inner = options ++ c.inner })

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -68,6 +68,7 @@ type alias Config m =
   , step : Float
   , listener : Maybe (Float -> m)
   , disabled : Bool
+  , inner : List (Options.Style m)
   }
 
 
@@ -79,6 +80,7 @@ defaultConfig =
   , step = 1
   , listener = Nothing
   , disabled = False
+  , inner = []
   }
 
 
@@ -209,6 +211,9 @@ view options =
           , Options.disabled config.disabled
             -- FIX for Firefox problem where you had to click on the 2px tall slider to initiate drag
           , css "padding" "8px 0"
+            -- NOTE: This is last here because of how attributes are collected
+            -- This way inner attributes should not override necessary attributes
+          , Options.many config.inner
           ]
           [ Html.type' "range"
           , Html.max (toString config.max)

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -236,6 +236,8 @@ onFocus f =
 
 
 {-| Set properties on the actual `input` element in the Textfield.
+
+**Deprecated**. Use `Options.inner` instead. This value will disappear in 8.0.0.
 -}
 style : List (Options.Style m) -> Property m
 style =

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -88,7 +88,7 @@ type Kind
   | Password
 
 
-type alias Config m = 
+type alias Config m =
   { labelText : Maybe String
   , labelFloat : Bool
   , error : Maybe String
@@ -99,7 +99,7 @@ type alias Config m =
   , cols : Maybe Int
   , autofocus : Bool
   , maxlength : Maybe Int
-  , style : List (Options.Style m)
+  , inner : List (Options.Style m)
   , listeners : List (Html.Attribute m)
   }
 
@@ -116,7 +116,7 @@ defaultConfig =
   , cols = Nothing
   , autofocus = False
   , maxlength = Nothing
-  , style = []
+  , inner = []
   , listeners = []
   }
 
@@ -237,10 +237,9 @@ onFocus f =
 
 {-| Set properties on the actual `input` element in the Textfield.
 -}
-style : List (Style m) -> Property m
-style style =
-  Options.set
-    (\config -> { config | style = style ++ config.style })
+style : List (Options.Style m) -> Property m
+style =
+  Options.inner
 
 
 {-| Sets the type of input to 'password'.
@@ -405,7 +404,7 @@ view lift model options =
            ])
       )
       [ Options.styled' elementFunction
-          [ Options.many config.style
+          [ Options.many config.inner
           , cs "mdl-textfield__input"
           , css "outline" "none"
           ]

--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -78,6 +78,7 @@ import Platform.Cmd
 import Parts exposing (Indexed)
 
 import Material.Options as Options exposing (cs, css, nop, Style)
+import Material.Options.Internal as Internal
 
 
 -- OPTIONS
@@ -406,14 +407,22 @@ view lift model options =
            ])
       )
       [ Options.styled' elementFunction
-          [ Options.many config.inner
-          , cs "mdl-textfield__input"
+          [ cs "mdl-textfield__input"
           , css "outline" "none"
+
+            {- NOTE: Ordering here is important.
+            Currently former attributes override latter ones.
+            If this changes this needs to be changed as well.
+            Currently this makes sure that even if users provide
+            Html.Events.on "focus" ... it would not have precedence
+            over our own focus handler.
+             -}
+          , Internal.attribute <| Html.Events.on "focus" (Decoder.succeed (lift Focus))
+          , Internal.attribute <| Html.Events.on "blur" (Decoder.succeed (lift Blur))
+          , Options.many config.inner
           ]
           ([ Html.Attributes.disabled config.disabled 
            , Html.Attributes.autofocus config.autofocus
-           , Html.Events.on "focus" (Decoder.succeed (lift Focus))
-           , Html.Events.on "blur" (Decoder.succeed (lift Blur))
            ] ++ textValue ++ typeAttributes ++ maxlength ++ listeners)
           []
       , Html.label 

--- a/src/Material/Toggles.elm
+++ b/src/Material/Toggles.elm
@@ -111,6 +111,7 @@ type alias Config m =
   , ripple : Bool
   , group : Maybe (Attribute m)
   , onClick : Maybe (Attribute m)
+  , inner : List (Options.Style m)
   }
 
 
@@ -121,6 +122,7 @@ defaultConfig =
   , ripple = False
   , group = Nothing
   , onClick = Nothing
+  , inner = []
   }
 
 
@@ -213,9 +215,11 @@ viewCheckbox lift model config elems =
     summary = Options.collect defaultConfig config
     cfg = summary.config
   in 
-    [ input
+    [ Options.styled' Html.input
+      [ cs "mdl-checkbox__input"
+      , Options.many cfg.inner
+      ]
       [ type' "checkbox"
-      , class ("mdl-checkbox__input")
       , Html.Attributes.disabled cfg.isDisabled
       , checked cfg.value 
         {- The checked attribute is not rendered. Switch still seems to
@@ -244,9 +248,11 @@ viewSwitch lift model config elems =
     summary = Options.collect defaultConfig config
     cfg = summary.config
   in 
-    [ input
+    [ Options.styled' Html.input
+      [ cs "mdl-switch__input"
+      , Options.many cfg.inner
+      ]
       [ type' "checkbox"
-      , class "mdl-switch__input"
       , Html.Attributes.disabled cfg.isDisabled
       , checked cfg.value 
         {- the checked attribute is not rendered. Switch still seems to
@@ -272,10 +278,12 @@ viewRadio lift model config elems =
     summary = Options.collect defaultConfig config
     cfg = summary.config
   in 
-    [ input 
+    [ Options.styled' Html.input
+      [ cs "mdl-radio__button"
+      , Options.many cfg.inner
+      ]
       (List.filterMap identity 
         [ Just (type' "radio")
-        , Just (class "mdl-radio__button")
         , Just (Html.Attributes.disabled cfg.isDisabled)
         , Just (checked cfg.value)
         , cfg.group


### PR DESCRIPTION
Resolves #204

`Options.id` allows users to specify the `id` that can then be
used with the new DOM API.
`Options.inner` allows users to specify attributes on `inner`
elements of components that support it.

I went through the list by @debois in #204. Only components that I really found needing support for `Options.inner` were `Textfield` as well as `Toggles`, both of them have `input` elements that the users can now add attributes to with `Options.inner`. 

Most of the other components have users specify sections of content already and for those they can just use `Options.id` (such as Tabs and Grids). For other components there was really no clear `inner` element that would benefit from enabling this support.

As always looking for feedback and suggestions, especially if there is a component that could really use `Options.inner` support