### PR TITLE
Add support for Link Buttons

### DIFF
--- a/demo/Demo/Buttons.elm
+++ b/demo/Demo/Buttons.elm
@@ -242,7 +242,7 @@ view model =
     , Button.render Mdl [9, 0, 0, 1] model.mdl
         [ Button.ripple
         , Button.link
-            [ Html.Attributes.href "#buttons"
+            [ Button.href "#buttons"
             ]
         ]
         [ text "Basic Link" ]
@@ -252,7 +252,7 @@ view model =
       Button.render Mdl [9, 0, 0, 1] model.mdl
         [ Button.ripple
         , Button.link
-            [ Html.Attributes.href "#buttons"
+            [ Button.href "#buttons"
             ]
         ]
         [ text "Basic Link" ]
@@ -263,8 +263,8 @@ view model =
         , Button.colored
         , Button.raised
         , Button.link
-            [ Html.Attributes.href "https://github.com/debois/elm-mdl/"
-            , Html.Attributes.target "_blank"
+            [ Button.href "https://github.com/debois/elm-mdl/"
+            , Button.target "_blank"
             ]
         ]
         [ text "View Source" ]
@@ -275,8 +275,8 @@ view model =
         , Button.colored
         , Button.raised
         , Button.link
-            [ Html.Attributes.href "https://github.com/debois/elm-mdl/"
-            , Html.Attributes.target "_blank"
+            [ Button.href "https://github.com/debois/elm-mdl/"
+            , Button.target "_blank"
             ]
         ]
         [ text "View Source" ]

--- a/demo/Demo/Buttons.elm
+++ b/demo/Demo/Buttons.elm
@@ -214,14 +214,14 @@ viewButtons model =
 
 view : Model -> Html Msg
 view model = 
-  Page.body2 "Buttons" srcUrl intro references  
+  Page.body1' "Buttons" srcUrl intro references
     [ p [] 
         [ text """Various combinations of colors and button styles can be seen
                   below. Most buttons have animations; try clicking. Code for the
                   last clicked button appears below the buttons."""
         ]
     , Grid.grid [] (viewButtons model)
-    , p []
+    , Options.styled p [ Options.css "min-height" "250px" ]
         [ model.last 
            |> Maybe.map describe 
            |> Maybe.map (\str -> "Code for '" ++ str ++ "':")
@@ -229,7 +229,59 @@ view model =
            |> text
         , Code.view model.code [ Options.css "margin" "20px" ]
         ]
-    ] 
+    ]
+    [ h4 [ id "link-buttons" ]
+        [ text "Link buttons"
+        ]
+
+    , p []
+        [ text """Link buttons are links that look and act like buttons.
+                However, they also support attributes for links such as 'href' and 'target'."""
+        ]
+
+    , Button.render Mdl [9, 0, 0, 1] model.mdl
+        [ Button.ripple
+        , Button.link
+            [ Html.Attributes.href "#buttons"
+            ]
+        ]
+        [ text "Basic Link" ]
+
+    , Code.code [ Options.css "margin" "20px 0" ]
+        """
+      Button.render Mdl [9, 0, 0, 1] model.mdl
+        [ Button.ripple
+        , Button.link
+            [ Html.Attributes.href "#buttons"
+            ]
+        ]
+        [ text "Basic Link" ]
+         """
+
+    , Button.render Mdl [9, 0, 0, 2] model.mdl
+        [ Button.ripple
+        , Button.colored
+        , Button.raised
+        , Button.link
+            [ Html.Attributes.href "https://github.com/debois/elm-mdl/"
+            , Html.Attributes.target "_blank"
+            ]
+        ]
+        [ text "View Source" ]
+    , Code.code [ Options.css "margin" "20px 0" ]
+        """
+      Button.render Mdl [9, 0, 0, 2] model.mdl
+        [ Button.ripple
+        , Button.colored
+        , Button.raised
+        , Button.link
+            [ Html.Attributes.href "https://github.com/debois/elm-mdl/"
+            , Html.Attributes.target "_blank"
+            ]
+        ]
+        [ text "View Source" ]
+         """
+    ]
 
 
 intro : Html a

--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -6,7 +6,9 @@ module Material.Button exposing
   , onClick
   , Property
   , render
+  , LinkProperty, LinkProp
   , link
+  , href, target, download, downloadAs, hreflang, media, ping, rel
   )
 
 {-| From the [Material Design Lite documentation](http://www.getmdl.io/components/#buttons-section):
@@ -47,13 +49,17 @@ for a live demo.
   
 ## Events
 @docs onClick
-@docs link
 
 ## Type 
 Refer to the
 [Material Design Specification](https://www.google.com/design/spec/components/buttons.html)
 for details about what type of buttons are appropriate for which situations.
 @docs flat, raised, fab, minifab, icon
+
+# Link Buttons
+@docs LinkProperty, LinkProp
+@docs link
+@docs href, target, download, downloadAs, hreflang, media, ping, rel
 
 # Elm architecture
 @docs Model, defaultModel, Msg, update, view
@@ -73,13 +79,89 @@ import Parts exposing (Indexed, Index)
 import Material.Helpers as Helpers
 import Material.Options as Options exposing (cs, when)
 import Material.Ripple as Ripple
+import Material.Options.Internal as Internal
+
+
+
+{-| Opaque link property type
+-}
+type LinkProp = LinkProp
+
+
+{-| Link properties
+-}
+type alias LinkProperty m =
+  Options.Property LinkProp m
+
+
+{-| Specifies the URL of the page the link goes to
+-}
+href : String -> LinkProperty m
+href =
+  Html.Attributes.href >> Internal.attribute
+
+
+{-| Specifies where to open the linked document.
+Possible values:
+
+  * _blank &mdash; a new window or tab
+  * _self &mdash; the same frame (this is default)
+  * _parent &mdash; the parent frame
+  * _top &mdash; the full body of the window
+
+-}
+target : String -> LinkProperty m
+target =
+  Html.Attributes.target >> Internal.attribute
+
+
+{-| Specifies that the target will be downloaded when a user clicks on the link
+-}
+download: Bool -> LinkProperty m
+download =
+  Html.Attributes.download >> Internal.attribute
+
+
+{-| Indicates that clicking the link will download the resource
+directly, and that the downloaded resource with have the given filename.
+-}
+downloadAs: String -> LinkProperty m
+downloadAs =
+  Html.Attributes.downloadAs >> Internal.attribute
+
+
+{-| Specifies the language of the linked document
+-}
+hreflang: String -> LinkProperty m
+hreflang =
+  Html.Attributes.hreflang >> Internal.attribute
+
+
+{-| Specifies what media/device the linked document is optimized for
+-}
+media: String -> LinkProperty m
+media =
+  Html.Attributes.media >> Internal.attribute
+
+
+{-| Specify a URL to send a short POST request to when the user clicks on the link
+-}
+ping: String -> LinkProperty m
+ping =
+  Html.Attributes.ping >> Internal.attribute
+
+
+{-| Specifies the relationship between the current document and the linked document
+-}
+rel: String -> LinkProperty m
+rel =
+  Html.Attributes.rel >> Internal.attribute
 
 
 
 -- MODEL
 
-
-{-| 
+{-|
 -}
 type alias Model = Ripple.Model
 
@@ -115,7 +197,7 @@ type alias Config m =
   { ripple : Bool 
   , onClick : Maybe (Attribute m)
   , disabled : Bool
-  , linkOptions : List (Attribute m)
+  , linkOptions : List (LinkProperty m)
   }
 
 
@@ -156,15 +238,15 @@ This allows for links that look and feel like buttons but perform link actions.
     Button.render ...
       [ ...
       , Button.link
-          [ Html.Attributes.href "#some-link"
-          , Html.Attributes.target "_blank"
+          [ Button.href "#some-link"
+          , Button.target "_blank"
           ]
       ]
       [ ... ]
 
 **NOTE** An empty list keeps the element as `button`
 -}
-link : List (Attribute m) -> Property m
+link : List (LinkProperty m) -> Property m
 link opts =
   Options.set
     (\options -> { options | linkOptions = opts ++ options.linkOptions})
@@ -262,8 +344,11 @@ view lift model config html =
           Nothing
       ]
 
+
+    linkSummary = Options.collect LinkProp cfg.linkOptions
+
     linkOptions =
-      List.map Just cfg.linkOptions
+      List.map Just linkSummary.attrs
 
     buttonElement =
       case cfg.linkOptions of


### PR DESCRIPTION
Adds support for Link buttons to resolve #201 via 
```elm
    Button.render ...
      [ ...
      , Button.link
          [ Button.href "#some-link"
          , Button.target "_blank"
          ]
      ]
      [ ... ]
```
This allows for links that look and feel like buttons but perform link actions.
**NOTE** An empty list keeps the element as `button`

Additionally, using opaque `LinkProperty m` type to remove the possibility of introducing arbitrary `Html.Attributes` via `Button.link` (initial implementation allowed for Html.Attributes). These link properties could possibly be moved into a separate module for use in other modules if needed.

As always, open to feedback and suggestions