### PR TITLE
Elm-test framework and Travis CI speed improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ language: node_js
 
 cache:
   directories:
+    - elm-stuff/packages
     - tests/elm-stuff/build-artifacts
+    - tests/elm-stuff/packages
     - libsysconfcpus
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 node_js:
   - "4.0"
 
-
 install:
   - npm install -g elm@0.17.1 elm-test
   - elm package install --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 
 
 install:
-  - npm install -g elm@$0.17.1 elm-test
+  - npm install -g elm@0.17.1 elm-test
   - elm package install --yes
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,23 @@ language: node_js
 cache:
   directories:
     - tests/elm-stuff/build-artifacts
+    - libsysconfcpus
 
 node_js:
   - "4.0"
 
 install:
   - npm install -g elm@0.17.1 elm-test
+  - |
+    if [ ! -d libsysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git; 
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/libsysconfcpus;
+      make && make install;
+      cd ..;
+    fi
   - elm package install --yes
 
 script:
-  - elm-test
+  - libsysconfcpus/bin/sysconfcpus -n 2 elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ cache:
   directories:
     - tests/elm-stuff/build-artifacts
 
+os:
+  - linux
+  - osx
+
+env:
+  matrix:
+    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=4.0
+
+
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];
     then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,13 @@ cache:
   directories:
     - tests/elm-stuff/build-artifacts
 
-os:
-  - linux
-  - osx
+node_js:
+  - "4.3"
 
-env:
-  matrix:
-    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=4.0
-
-
-before_install:
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
-    fi
-  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
 install:
-  - nvm install $TARGET_NODE_VERSION
-  - nvm use $TARGET_NODE_VERSION
-  - node --version
-  - npm --version
-  - cd test
-  - npm install -g elm@$ELM_VERSION elm-test
-  - git clone https://github.com/NoRedInk/elm-ops-tooling
-  - elm-ops-tooling/with_retry.rb elm package install --yes
+  - npm install -g elm@$0.17.1 elm-test
+  - elm package install --yes
 
 script:
   - elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 sudo: false
-language: node_js
+
 cache:
   directories:
-    - $HOME/elm-stuff/build-artifacts
-    - demo/elm-stuff/build-artifacts
-node_js:
-  - "4.3"
+    - tests/elm-stuff/build-artifacts
+
+before_install:
+  - if [ ${TRAVIS_OS_NAME} == "osx" ];
+    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
+    fi
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+
 install:
-- npm install -g elm
-before_script:
-- elm-package install -y
+  - nvm install $TARGET_NODE_VERSION
+  - nvm use $TARGET_NODE_VERSION
+  - node --version
+  - npm --version
+  - cd test
+  - npm install -g elm@$ELM_VERSION elm-test
+  - git clone https://github.com/NoRedInk/elm-ops-tooling
+  - elm-ops-tooling/with_retry.rb elm package install --yes
+
 script:
-- make test
+  - elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 cache:
-
-directories:
-  - $HOME/elm-stuff/build-artifacts
-  - demo/elm-stuff/build-artifacts
+  directories:
+    - $HOME/elm-stuff/build-artifacts
+    - demo/elm-stuff/build-artifacts
 node_js:
   - "4.3"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
-language: haskell
+sudo: false
+language: node_js
+cache:
+
+directories:
+  - $HOME/elm-stuff/build-artifacts
+  - demo/elm-stuff/build-artifacts
+node_js:
+  - "4.3"
 install:
-  - npm install -g elm
-  - elm-package install -y
-script: 
-  - make test
-  
+- npm install -g elm
+before_script:
+- elm-package install -y
+script:
+- make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 sudo: false
 
+language: node_js
+
 cache:
   directories:
     - tests/elm-stuff/build-artifacts
 
 node_js:
-  - "4.3"
+  - "4.0"
 
 
 install:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Elm-mdl
 
-### This is only relevant when developers and contributors to Elm-mdl
+### This is only relevant for developers and contributors to Elm-mdl
 
 Tests are located in a separate *"tests"* folder and does not affect elm-mdl.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,25 @@
+# Testing Elm-mdl
+
+### This is only relevant when developers and contributors to Elm-mdl
+
+Tests are located in a separate *"tests"* folder and does not affect elm-mdl.
+
+Prerequisite: To be able to run tests from your terminal - install node-test-runner by running:
+> npm install -g elm-test
+
+Run all tests by executing this command in the root folder:
+>elm-test
+
+The travis.yml file has been configured to run elm-test when any branch is pushed to GitHub
+
+**NOTE**
+
+One primary reason to include elm-test now, is to improve the speed of Travis build.
+Currently, there are no actual tests implemented. The Material components and Demo components are imported by the testrunner and only verifies that building those modules does not fail.
+
+We should look at other projects to see how to implement tests in Elm-mdl.
+- [elm-test](https://github.com/elm-community/elm-test) - The elm-test package used
+- [elm-css](https://github.com/rtfeldman/elm-css) - A relevant project using elm-test.
+- [elm-combine](https://github.com/Bogdanp/elm-combine) - Another relevant project using elm-test.
+- [Caching elm builds on Travis](https://8thlight.com/blog/rob-looby/2016/04/07/caching-elm-builds-on-travis-ci.html)
+- [Article on testing in Elm](https://medium.com/@_rchaves_/testing-in-elm-93ad05ee1832#.tr0bpt18s) - Some parts are outdated.

--- a/USERS.md
+++ b/USERS.md
@@ -7,7 +7,7 @@
 * Hydra frontend - Hydra frontend rewritten with UX in mind.
     * [GitHub repository](https://github.com/domenkozar/hydra-frontend)
     * [Live demo/site](http://hydra-frontend.domenkozar.com/)
-* Elephant-guide - A simple Webpack setup for writing Elm apps.
+* Elephant-guide - Magic: the Gathering deck tuning tool.
     * [GitHub repository](https://github.com/IwalkAlone/elephant-guide)
 * Phoenix-Elm-Chat - Elm and Phoenix Chat Client.
     * This is a chat application that we build out in episodes on the Elm and Elixir tracks for DailyDrip

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+/elm-stuff
+elm.js
+index.html

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+
+
+main : Program Value
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,63 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import Expect
+
+--Do not delete these imports as they are beeing compiled even when not beeing tested directly
+
+import Material
+import Material.Color as Color
+import Material.Layout as Layout
+import Material.Helpers exposing (pure, lift, map1st, map2nd)
+import Material.Options as Options exposing (css, when)
+import Material.Scheme as Scheme
+import Material.Icon as Icon
+import Material.Typography as Typography
+import Material.Menu as Menu
+
+import Demo.Page as Page
+import Demo.Buttons
+import Demo.Menus
+import Demo.Tables
+import Demo.Grid
+import Demo.Textfields
+import Demo.Snackbar
+import Demo.Badges
+import Demo.Elevation
+import Demo.Toggles
+import Demo.Loading
+import Demo.Layout
+import Demo.Footer
+import Demo.Tooltip
+import Demo.Tabs
+import Demo.Slider
+import Demo.Typography
+import Demo.Cards
+import Demo.Lists
+import Demo.Dialog
+import Demo.Chips
+
+
+
+mainSuite : Test
+mainSuite =
+    describe "Main Test Suite"
+        [ test "Sample test" <|
+            \() ->
+                Expect.equal (1) 1
+        ]
+
+materialButtonSuite : Test
+materialButtonSuite =
+    describe "Material Button Test Suite"
+        [ test "Sample Button test" <|
+            \() ->
+                Expect.equal (1) 1
+        ]
+
+
+all : Test
+all =
+    describe "elm-css"
+        [ mainSuite
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -47,17 +47,8 @@ mainSuite =
                 Expect.equal (1) 1
         ]
 
-materialButtonSuite : Test
-materialButtonSuite =
-    describe "Material Button Test Suite"
-        [ test "Sample Button test" <|
-            \() ->
-                Expect.equal (1) 1
-        ]
-
-
 all : Test
 all =
-    describe "elm-css"
+    describe "elm-mdl"
         [ mainSuite
         ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0",
+    "summary": "Test project for Elm-mdl",
+    "repository": "https://github.com/debois/elm-mdl.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        ".",
+        "../examples",
+        "../demo",
+        "../src"
+        ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
+        "debois/elm-dom": "1.2.0 <= v < 2.0.0",
+        "debois/elm-parts": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "elm-lang/mouse": "1.0.0 <= v < 2.0.0",
+        "elm-lang/window": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-markdown": "3.0.0 <= v < 4.0.0",
+        "rgrempel/elm-route-url": "2.0.0 <= v < 3.0.0"    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "summary": "Test project for Elm-mdl",
     "repository": "https://github.com/debois/elm-mdl.git",
-    "license": "BSD-3-Clause",
+    "license": "Apache License, version 2.0",
     "source-directories": [
         ".",
         "../examples",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,7 +12,7 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-community/elm-test": "2.1.0 <= v < 3.0.0",
         "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
         "debois/elm-dom": "1.2.0 <= v < 2.0.0",
         "debois/elm-parts": "4.0.0 <= v < 5.0.0",
@@ -22,5 +22,5 @@
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
         "evancz/elm-markdown": "3.0.0 <= v < 4.0.0",
         "rgrempel/elm-route-url": "2.0.0 <= v < 3.0.0"    },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.17.1 <= v < 0.18.0"
 }


### PR DESCRIPTION
This adds a separate tests folder to elm-mdl. This does not affect elm-mdl in any way. I've also update the travis.yml file to use caching (reduces build time from 43 to 17 minutes) and use the test framework.

The current Travis CI build speed is 40-50 minutes. A couple of weeks ago, I tested the caching described in this [article](https://8thlight.com/blog/rob-looby/2016/04/07/caching-elm-builds-on-travis-ci.html), but with no luck. 

All other examples used [elm-test](https://github.com/elm-community/elm-test) as the last step in Travis CI, so I've implemented some basic tests using [elm-test](https://github.com/elm-community/elm-test). The Travis CI build is now down to 17 minutes - it's possible that it can be reduced more by caching the entire "elm-stuff" folder.

One primary reason I had to include elm-test now, is to improve the speed of Travis build.
Currently, there are no actual tests implemented. The Material components and Demo components are imported by the testrunner and only verifies that building those modules does not fail.

I've included a TESTING.md file with documentation on how to use testing in elm-mdl, but it's currently not required for running and developing elm-mdl.

The TESTING.md also references other projects using elm-test, to give some ideas on how to test elm-mdl. Testing can be helpful, but I'm not sure how elm-mdl Material components can be tested. Do you have any feedback or opinions on this?

