### PR TITLE
LICENSE UPDATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ demo](https://debois.github.io/elm-mdl/); check out [the
 documentation](http://package.elm-lang.org/packages/debois/elm-mdl/latest/), or
 ask on [#elm-mdl in the elm-slack](https://elm.slack.com/messages/elm-mdl) for
 help in migrating.
+ 


### PR DESCRIPTION
I agree with my previous contributions licensed under BSD3 now being contributions under Apache v2.

BSD3: https://opensource.org/licenses/BSD-3-Clause
Apache v2: https://www.apache.org/licenses/LICENSE-2.0