### PR TITLE
Correct project description in USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -7,7 +7,7 @@
 * Hydra frontend - Hydra frontend rewritten with UX in mind.
     * [GitHub repository](https://github.com/domenkozar/hydra-frontend)
     * [Live demo/site](http://hydra-frontend.domenkozar.com/)
-* Elephant-guide - A simple Webpack setup for writing Elm apps.
+* Elephant-guide - Magic: the Gathering deck tuning tool.
     * [GitHub repository](https://github.com/IwalkAlone/elephant-guide)
 * Phoenix-Elm-Chat - Elm and Phoenix Chat Client.
     * This is a chat application that we build out in episodes on the Elm and Elixir tracks for DailyDrip


### PR DESCRIPTION
Accidentally noticed that my project is in USERS.md. I was confused why I was getting traffic on it all of a sudden :)

Here's a correct description for my project - the previous one was leftover from a starter kit I forked. Wouldn't want people to come there thinking it's a webpack boilerplate :) (that would be https://github.com/moarwick/elm-webpack-starter, which is awesome)