### PR TITLE
Change links from fixed to relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ or on [#elm-mdl](https://elm.slack.com/messages/elm-mdl) in the elm-slack.
 
 
 ### Frequently asked questions
-Please read the [FAQ here](FAQ.md)
+Please read the [FAQ here](https://github.com/debois/elm-mdl/blob/v7/FAQ.md)
 
 
 ### Other projects using Elm-mdl
 
-Check out the [users page](USERS.md) for a list of projects using elm-mdl.
+Check out the [users page](https://github.com/debois/elm-mdl/blob/v7/USERS.md) for a list of projects using elm-mdl.
 
 ### Contribute
 


### PR DESCRIPTION
Changes links for FAQ.md and USERS.md

According to issue #214, elm-package currently does not like relative links in README. I've updated to fixed links - pointing to v7 branch. I noticed that the link to CONTRIBUTING.md was pointing to master.