### PR TITLE
Add a commit hook to warn on incorrect commit message

### DIFF
--- a/build_scripts/hooks/commit-msg
+++ b/build_scripts/hooks/commit-msg
@@ -41,4 +41,5 @@ while True:
         print '# Git commit message warnings:\nThese are guidelines to help us improve commit messages.'
         for error in errors:
             print '{}'.format(error)
+        print 'You can run <git commit --amend> to fix this message.'
     break

--- a/build_scripts/hooks/commit-msg
+++ b/build_scripts/hooks/commit-msg
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import sys, os
+from subprocess import call
+
+message_file = sys.argv[1]
+
+def check_format_rules(lineno, line):
+    real_lineno = lineno + 1
+    if lineno == 0:
+        linewarning = ""
+        if len(line) > 50:
+            linewarning = "Warning - line %d: Please limit the subject line to 50 characters." \
+                    "in length.\n" % (real_lineno,)
+        if not line[0].isupper() :
+            linewarning = linewarning + "Warning - line %d: Please capitalize the subject line.\n" % (real_lineno,)
+        if line.endswith('.') :
+            linewarning = linewarning +  "Warning - line %d: Please do not end the subject line with a period." % (real_lineno,)
+        if linewarning:
+            return linewarning
+    if lineno == 1:
+        if line:
+            return "Warning - line %d: Please separate subject from body with a blank line." % (real_lineno,)
+    if not line.startswith('#'):
+        if len(line) > 72:
+            return "Warning - line %d: Please wrap the body at 72 characters." % (real_lineno,)
+    return False
+
+
+while True:
+    commit_msg = list()
+    errors = list()
+    with open(message_file) as commit_fd:
+        for lineno, line in enumerate(commit_fd):
+            stripped_line = line.strip()
+            commit_msg.append(line)
+            e = check_format_rules(lineno, stripped_line)
+            if e:
+                errors.append(e)
+    if errors:
+        print '# Git commit message warnings:\nThese are guidelines to help us improve commit messages.'
+        for error in errors:
+            print '{}'.format(error)
+    break

--- a/build_scripts/install_hooks.sh
+++ b/build_scripts/install_hooks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#Based on article here: https://www.sitepoint.com/introduction-git-hooks/
+#Create a hooks directory and a simple installer install-hooks.sh that links them (rather than copying):
+#Anyone who clones your project can simply run bash install-hooks.sh after cloning.
+#This is currently not working. Unable to find correct directory
+
+for i in hooks/*; do ln -s "${i}" ".git/${i}"; done


### PR DESCRIPTION
As discussed earlier on guiding us into making correct commit messages.

I've modified the script [here](http://stackoverflow.com/questions/21641085/how-do-i-enforce-the-50-character-commit-summary-line-in-sublime)

I've changed the implementation to only gently warn when not making a correct commit message.
This is the result from a message that break all the rules:
`

> Git commit message warnings:
> These are guidelines to help us improve commit messages.
> Warning - line 1: Please limit the subject line to 50 characters.in length.
> Warning - line 1: Please capitalize the subject line.
> Warning - line 1: Please do not end the subject line with a period.
> Warning - line 2: Please separate subject from body with a blank line.
> Warning - line 4: Please wrap the body at 72 characters.
> Warning - line 6: Please wrap the body at 72 characters.

Users can opt into using these hooks. To simplify sharing, I've also created a bash script based on the article [here](https://www.sitepoint.com/introduction-git-hooks/) on how to share git hooks. This script is currently not finding the correct directory for .git/hooks. You can still use the commit-msg hook by copying it into .git/hooks.

I'm only testing this out. It's totally ok if we don't use this PR :)
`
