### PR TITLE
Update broken Demo link references

### DIFF
--- a/demo/Demo/Dialog.elm
+++ b/demo/Demo/Dialog.elm
@@ -95,6 +95,6 @@ srcUrl =
 references : List (String, String)
 references =
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Dialog"
-  , Page.mds "https://material.google.com/components/dialog.html"
+  , Page.mds "https://material.google.com/components/dialogs.html"
   , Page.mdl "https://getmdl.io/components/#dialog-section"
   ]

--- a/demo/Demo/Elevation.elm
+++ b/demo/Demo/Elevation.elm
@@ -197,7 +197,7 @@ view model =
 
 intro : Html a
 intro =
-  Page.fromMDL "https://github.com/google/material-design-lite/blob/master/src/shadow/README.md" """
+  Page.fromMDL "https://github.com/google/material-design-lite/blob/mdl-1.x/src/shadow/README.md" """
   > The Material Design Lite (MDL) shadow is not a component in the same sense as
 > an MDL card, menu, or textbox; it is a visual effect that can be assigned to a
 > user interface element. The effect simulates a three-dimensional positioning of
@@ -233,7 +233,7 @@ references : List (String, String)
 references = 
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Elevation"
   , Page.mds "https://www.google.com/design/spec/what-is-material/elevation-shadows.html"
-  , Page.mdl "https://github.com/google/material-design-lite/blob/master/src/shadow/README.md"
+  , Page.mdl "https://github.com/google/material-design-lite/blob/mdl-1.x/src/shadow/README.md"
   ]
 
 

--- a/demo/Demo/Loading.elm
+++ b/demo/Demo/Loading.elm
@@ -199,6 +199,6 @@ srcUrl =
 references : List (String, String)
 references =
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Loading"
-  , Page.mds "https://www.google.com/design/spec/components/Loading.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#Loading"
+  , Page.mds "https://material.google.com/components/progress-activity.html"
+  , Page.mdl "https://getmdl.io/components/index.html#loading-section"
   ]

--- a/demo/Demo/Tables.elm
+++ b/demo/Demo/Tables.elm
@@ -453,5 +453,5 @@ references : List (String, String)
 references =
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Table"
   , Page.mds "https://www.google.com/design/spec/components/data-tables.html"
-  , Page.mdl "https://www.getmdl.io/components/index.html#tables"
+  , Page.mdl "https://getmdl.io/components/index.html#tables-section"
   ]

--- a/demo/Demo/Toggles.elm
+++ b/demo/Demo/Toggles.elm
@@ -258,7 +258,7 @@ view model =
 
 intro : Html Msg
 intro = 
-  Page.fromMDL "http://www.getmdl.io/index.html#toggles-section/checkbox" """
+  Page.fromMDL "https://getmdl.io/components/index.html#toggles-section" """
 > The Material Design Lite (MDL) checkbox component is an enhanced version of the
 > standard HTML `<input type="checkbox">` element. A checkbox consists of a small
 > square and, typically, text that clearly communicates a binary condition that
@@ -285,7 +285,7 @@ references : List (String, String)
 references = 
   [ Page.package "http://package.elm-lang.org/packages/debois/elm-mdl/latest/Material-Toggles"
   , Page.mds "https://www.google.com/design/spec/components/selection-controls.html"
-  , Page.mdl "http://www.getmdl.io/index.html#toggles-section/checkbox"
+  , Page.mdl "https://getmdl.io/components/index.html#toggles-section"
   ]
 
 


### PR DESCRIPTION
Updates all of the outdated link references in the Demo.
- [Material Design Component Dialogs](https://material.google.com/components/dialogs.html)
- [Material Design Component Loading](https://material.google.com/components/progress-activity.html)
- [Material Design Lite Elevation/Shadow](https://github.com/google/material-design-lite/blob/mdl-1.x/src/shadow/README.mdl)
- [Material Design Lite Loading](https://getmdl.io/components/index.html#loading-section)
- [Material Design Lite Tables](https://getmdl.io/components/index.html#tables-section)
- [Material Design Lite Toggles](https://getmdl.io/components/index.html#toggles-section)
