### PR TITLE
V8 upgrade and fix elm test

### DIFF
--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,11 +1,11 @@
 port module Main exposing (..)
 
 import Tests
-import Test.Runner.Node exposing (run)
+import Test.Runner.Node exposing (run, TestProgram)
 import Json.Encode exposing (Value)
 
 
-main : Program Value
+main : TestProgram
 main =
     run emit Tests.all
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,7 +20,7 @@ import Demo.Buttons
 import Demo.Menus
 import Demo.Tables
 import Demo.Grid
-import Demo.Textfields
+--import Demo.Textfields
 import Demo.Snackbar
 import Demo.Badges
 import Demo.Elevation

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,7 +20,7 @@ import Demo.Buttons
 import Demo.Menus
 import Demo.Tables
 import Demo.Grid
---import Demo.Textfields
+import Demo.Textfields
 import Demo.Snackbar
 import Demo.Badges
 import Demo.Elevation

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,16 +11,15 @@
         ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-community/elm-test": "2.1.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
-        "debois/elm-dom": "1.2.0 <= v < 2.0.0",
-        "debois/elm-parts": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "elm-lang/mouse": "1.0.0 <= v < 2.0.0",
-        "elm-lang/window": "1.0.0 <= v < 2.0.0",
-        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-markdown": "3.0.0 <= v < 4.0.0",
-        "rgrempel/elm-route-url": "2.0.0 <= v < 3.0.0"    },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+        "debois/elm-dom": "1.2.3 <= v < 2.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/mouse": "1.0.1 <= v < 2.0.0",
+        "elm-lang/window": "1.0.1 <= v < 2.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
+        "evancz/elm-markdown": "3.0.1 <= v < 4.0.0",
+        "rgrempel/elm-route-url": "3.0.0 <= v < 4.0.0"    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,6 +12,7 @@
     "exposed-modules": [],
     "dependencies": {
         "debois/elm-dom": "1.2.3 <= v < 2.0.0",
+        "elm-lang/dom": "1.1.1 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/mouse": "1.0.1 <= v < 2.0.0",


### PR DESCRIPTION
Elm-test packages updated to current versions. They also needs to be in sync with root elm-package to work correctly. Seems to work ok with travis on my fork.