### PR TITLE
added Options.node to enable adding any type of node to an elm-mdl node

### DIFF
--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -103,12 +103,12 @@ view model =
             [ Options.onClick Increase
             , css "margin" "0 24px"
             ]
-            [ text "Increase" ]
+            [ Options.node "div" [] [ text "Increase" ] ]
         , Button.render Mdl
             [ 1 ]
             model.mdl
             [ Options.onClick Reset ]
-            [ text "Reset" ]
+            [ Options.node "div" [] [ text "Reset" ] ]
         ]
         |> Material.Scheme.top
 

--- a/src/Material/Options.elm
+++ b/src/Material/Options.elm
@@ -13,6 +13,7 @@ module Material.Options
         , styled_
         , stylesheet
         , Style
+        , node
         , div
         , span
         , img
@@ -88,7 +89,7 @@ elements.
 @docs Style, styled, styled_
 
 ## Elements
-@docs div, span, img
+@docs node, div, span, img
 @docs stylesheet
 
 ## Attributes
@@ -123,7 +124,7 @@ as follows:
   <tr>
     <th>Option</th><th>Element</th>
   </tr>
-  <tr> <td>`Options.id`         </td><td> input     </td> </tr> 
+  <tr> <td>`Options.id`         </td><td> input     </td> </tr>
   <tr> <td>`Options.css`        </td><td> container </td> </tr>
   <tr> <td>`Options.cs`         </td><td> container </td> </tr>
   <tr> <td>`Options.attributes` </td><td> input     </td> </tr>
@@ -147,7 +148,6 @@ import Html.Attributes
 import Html.Events
 import Json.Decode as Json
 import Material.Options.Internal as Internal exposing (..)
-
 
 
 -- PROPERTIES
@@ -200,16 +200,33 @@ styled_ ctor props attrs =
         )
 
 
-{-| Convenience function for the ultra-common case of apply elm-mdl styling to a
-`div` element. Use like this:
+{-| Convenience function for the case of apply elm-mdl styling to a
+`node` element that is not defined in elm-mdl. Use like this:
 
     myDiv : Html m
     myDiv =
-      Options.div
+      Options.node "div"
         [ Color.background Color.primary
         , Color.text Color.accentContrast
         ]
         [ text "I'm in color!" ]
+
+-}
+node : String -> List (Property c m) -> List (Html m) -> Html m
+node nodeType =
+    styled (Html.node nodeType)
+
+
+{-| Convenience function for the ultra-common case of apply elm-mdl styling to a
+`div` element. Use like this:
+
+myDiv : Html m
+myDiv =
+Options.div
+[ Color.background Color.primary
+, Color.text Color.accentContrast
+]
+[ text "I'm in color!" ]
 
 -}
 div : List (Property c m) -> List (Html m) -> Html m
@@ -291,7 +308,7 @@ applied; otherwise it is ignored. Use like this:
     Button.disabled |> when (not model.isRunning)
 -}
 when : Bool -> Property c m -> Property c m
-when guard prop  =
+when guard prop =
     if guard then
         prop
     else
@@ -316,6 +333,7 @@ somewhere.
 stylesheet : String -> Html m
 stylesheet css =
     Html.node "style" [] [ Html.text css ]
+
 
 
 -- STYLE


### PR DESCRIPTION
I want to embed some SVG in the button which I think I cannot do currently:
```
Button.render Mdl
                [ 0 ]
                model.mdl
                [ Button.icon
                ]
                  [ Options.node "svg" [ css "width" "24px", css "height" "24px", viewBox "0 0 24 24"]
                                                      [ Options.node "path" [Options.attribute fill "#000000",  Options.attribute d="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z"
                                                      ]
                ]
```
Looking at the elm-mdl code again, I guess I can do it with `Options.styled Html.node "svg" [] []` but that is not very discoverable :) 