### PR TITLE
Fix textfield demos to use Textfield.value to manage is-dirty

### DIFF
--- a/demo/Demo/Textfields.elm
+++ b/demo/Demo/Textfields.elm
@@ -168,11 +168,15 @@ textfields model =
       , Textfield.render Mdl
             [ 0 ]
             model.mdl
-            [ Options.onInput Upd0 ]
+            [ Options.onInput Upd0
+            , Textfield.value model.str0
+            ]
             []
       , """
         Textfield.render Mdl [0] model.mdl
-          [ Options.onInput Upd0 ]
+          [ Options.onInput Upd0
+          , Textfield.value model.str0
+          ]
           []
        """
       )
@@ -358,6 +362,7 @@ textfields model =
                         ++ " char limit)"
                     )
                 , Options.onInput Upd6
+                , Textfield.value model.str6
                 , Textfield.textarea
                 , Textfield.maxlength (truncate model.length)
                 , Textfield.floatingLabel
@@ -385,6 +390,7 @@ textfields model =
                 ++ " of " ++ (toString (truncate model.length))
                 ++ " char limit)")
          , Options.onInput Upd6
+         , Textfield.value model.str6
          , Textfield.textarea
          , Textfield.maxlength (truncate model.length)
          , Textfield.floatingLabel


### PR DESCRIPTION
Currently `Textfield` does not properly update its internal is-dirty
state when using user provided `Options.onInput`. Workaround
is to call `Textfield.value` with the input.

This would cause floating labels to not float properly when unfocused.