### PR TITLE
Fix regression on the handling of deleteClick

### DIFF
--- a/src/Material/Chip.elm
+++ b/src/Material/Chip.elm
@@ -40,6 +40,7 @@ for a live demo.
 
 import Html exposing (Attribute, Html)
 import Html.Attributes
+import Html.Events
 import Material.Options as Options exposing (cs)
 import Material.Icon as Icon
 import Material.Options.Internal as Internal
@@ -106,11 +107,18 @@ NOTE. This stops propagation and prevents default to stop `onClick` from being
 called when this is clicked.
 -}
 deleteClick : msg -> Property msg
-deleteClick msg =
-    Options.onWithOptions
-      "click" 
-       { stopPropagation = True, preventDefault = True }
-       (Json.succeed msg)
+deleteClick =
+    Internal.option
+        << (\msg config ->
+                { config
+                    | deleteClick =
+                        Just
+                            (Html.Events.onWithOptions "click"
+                                { stopPropagation = True, preventDefault = True }
+                                (Json.succeed msg)
+                            )
+                }
+           )
 
 type alias Priority =
     Int


### PR DESCRIPTION
Commit 98f4284907e9fac removed (apparently accidentally) some code which used to set up the Chip model's `deleteClick` attribute. After 98f4284907e9fac, `deleteClick` will never be set. It will always be equal to `Nothing`.

The following snippet currently just overrides `Log "onClick"` with `Log "deleteClick"`. It is thus impossible to set up both `onClick` and `deleteClick` in the same Chip correctly. Please note that `deleteLink` was not affected by this issue. 

```elm
Chip.span
    [ Chip.deleteIcon "cancel"
    , Options.onClick (Log "onClick")
    , Chip.deleteClick (Log "deleteClick")
    ]
    [ Chip.content []
        [ text "chip" ]
    ]
```

By partially reverting the change as per this pull request, the issue is fixed.