### PR TITLE
Fix minifab buttons not applying fab-class

### DIFF
--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -367,7 +367,10 @@ fab =
 -}
 minifab : Property m
 minifab =
-    cs "mdl-button--mini-fab"
+    Options.many
+        [ cs "mdl-button--mini-fab"
+        , fab
+        ]
 
 
 {-| The [Material Design Lite implementation](https://www.getmdl.io/components/index.html#buttons-section)


### PR DESCRIPTION
Minifab buttons also need mdl-button--fab class.