### PR TITLE
Expose Material.Textfield.Config

### DIFF
--- a/src/Material/Textfield.elm
+++ b/src/Material/Textfield.elm
@@ -19,6 +19,7 @@ module Material.Textfield
         , expandable
         , expandableIcon
         , Model
+        , Config
         , defaultModel
         , Msg(..)
         , update


### PR DESCRIPTION
I would like to create a package that wraps `textfield` and appends a default list of `List Options.Property` to a list of options that is passed in. I don't believe it is possible to create a type signature for this function (and a type signature is required to publish the package) without exposing `Material.Textfield.Config`.

```
The right side of (++) is causing a type mismatch.

45|          options ++ validationOptions)
                        ^^^^^^^^^^^^^^^^^
(++) is expecting the right side to be a:

    List (Options.Property a msg)

But the right side is:

    List (Options.Property (Material.Textfield.Config msg) msg)
```

It would be great if you could expose this type in the next release. Thanks for the library!