### PR TITLE
Fix slider thumb in MS Edge

### DIFF
--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -203,6 +203,8 @@ view options =
                 , cs "is-lowest-value" |> when (fraction == 0)
                   -- FIX for Firefox problem where you had to click on the 2px tall slider to initiate drag
                 , css "padding" "8px 0"
+                  -- FIX for MS Edge problem with input "range" height not depending on thumb height and clipping it
+                , css "min-height" "20px"
                 , Internal.attribute <| Html.type_ "range"
                 , Internal.attribute <| Html.max (toString config.max)
                 , Internal.attribute <| Html.min (toString config.min)


### PR DESCRIPTION
This fixes issue #1625 by preventing the thumb from being clipped. The issue exists in [https://github.com/google/material-design-lite/blob/mdl-1.x/src/slider/_slider.scss](Google MDL).