### PR TITLE
Fix documention error:

### DIFF
--- a/demo/Demo/Tables.elm
+++ b/demo/Demo/Tables.elm
@@ -408,7 +408,7 @@ sortable model =
                         Just x ->
                             "Table." ++ toString x ++ ", "
                    )
-                ++ """Table.onClick Reorder ]
+                ++ """Options.onClick Reorder ]
                   [ text "Material" ]
               , Table.th [ Table.numeric ] [ text "Quantity" ]
               , Table.th [ Table.numeric ] [ text "Unit Price" ]


### PR DESCRIPTION
- `Table.onClick` yields:

```
Cannot find variable `Table.onClick`.
```

- `onClick` is defined in the module `Material.Options`