### PR TITLE
Fix : hide Grid.All

### DIFF
--- a/src/Material/Grid.elm
+++ b/src/Material/Grid.elm
@@ -42,7 +42,7 @@ Example use:
 
     import Material.Grid exposing (grid, cell, size, Device(..))
 
-    top : (Html a)
+    top : Html a
     top =
       grid []
         [ cell [ size All 4 ]
@@ -207,6 +207,11 @@ stretch =
     cs "mdl-cell--stretch"
 
 
+classForHide : Device -> String
+classForHide device =
+    "mdl-cell--hide" ++ suffix device
+
+
 {-| Specify that a cell should be hidden on given `Device`.
 -}
 hide : Device -> Style a
@@ -214,10 +219,12 @@ hide device =
     cs <|
         case device of
             All ->
-                ""
+                [ Desktop, Tablet, Phone ]
+                    |> List.map classForHide
+                    |> String.join " "
 
             _ ->
-                "mdl-cell--hide" ++ suffix device
+                classForHide device
 
 
 {-| Specify that a cell should re-order itself to position 'Int' on `Device`.


### PR DESCRIPTION
Add all elm-mdl--hide-* classes when hide with Grid.All devices is used.

Current : When we use `Grid.hide Grid.All` we don't add any hide class for the device.
Expected : We should add hide class for all devices.

Use case :

in elm grid : 
I may add `hide Style` on the grid Cell based on some logic. E.g. on press state of a help-button, we want to show a help message. so, to logic of showing help message used `Grid.hide Grid.All` with a condition.

```
Grid.cell [ if model.showHelpMsg 
               then Grid.size Grid.All 12 
               else Grid.hide Grid.All 
                ] 
               [ .. view .. ]
```
