### PR TITLE
Remove extra - from class name

### DIFF
--- a/src/Material/Grid.elm
+++ b/src/Material/Grid.elm
@@ -217,7 +217,7 @@ hide device =
                 ""
 
             _ ->
-                "mdl-cell--hide-" ++ suffix device
+                "mdl-cell--hide" ++ suffix device
 
 
 {-| Specify that a cell should re-order itself to position 'Int' on `Device`.


### PR DESCRIPTION
As noted by @bruunoromero the suffix device has a hyphen at the start.

The hide class should only contain one - like `mdl-cell--hide-phone`.

Fix #356