### PR TITLE
added link to layout template/example

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -7,4 +7,7 @@ Below is a list of templates for getting started with `elm-mdl`.
     * [GitHub repository](https://github.com/vipentti/elm-mdl-dashboard)
     * [Live demo](https://vipentti.github.io/elm-mdl-dashboard)
 
+* Layout template - Quick start using Layouts in elm-mdl
+    * [GitHub repository](https://github.com/glennular/elm-mdl-layout-starter/)
+    * [Live demo](https://glennular.github.io/elm-mdl-layout-starter/)
 


### PR DESCRIPTION
I found creating all the elements of Material.Layout to be a tedious step when kicking off a new project.  When I just want a Hellow World app to run, it takes a little bit to get the Layout be code. So I built this to drop into new projects and go from there.

Let me know if you have any thoughts or improvements.