### PR TITLE
WIP: Fix broken Menu.icon option in the v9 branch

### DIFF
--- a/src/Material/Menu.elm
+++ b/src/Material/Menu.elm
@@ -418,7 +418,7 @@ view lift model properties items =
                   }
               """
             ]
-            [ Icon.view model.icon
+            [ Icon.view config.icon
                 [ cs "material-icons"
                 , css "pointer-events" "none"
                 ]

--- a/src/Material/Menu.elm
+++ b/src/Material/Menu.elm
@@ -418,7 +418,7 @@ view lift model properties items =
                   }
               """
             ]
-            [ Icon.view menu.icon
+            [ Icon.view model.icon
                 [ cs "material-icons"
                 , css "pointer-events" "none"
                 ]

--- a/src/Material/Menu.elm
+++ b/src/Material/Menu.elm
@@ -112,7 +112,7 @@ import Material.Internal.Dropdown as Dropdown
 import Material.Internal.Geometry as Geometry exposing (Geometry)
 import Material.Internal.Menu exposing (ItemInfo, Msg(..))
 import Material.Internal.Options as Internal
-import Material.Msg exposing (Index) 
+import Material.Msg exposing (Index)
 import Material.Options as Options exposing (Style, cs, css, styled, styled_, when)
 import Material.Ripple as Ripple
 import Mouse
@@ -418,7 +418,7 @@ view lift model properties items =
                   }
               """
             ]
-            [ Icon.view "more_vert"
+            [ Icon.view menu.icon
                 [ cs "material-icons"
                 , css "pointer-events" "none"
                 ]


### PR DESCRIPTION
Looks like Menu.icon was properly implemented in https://github.com/debois/elm-mdl/pull/65 but that it was not fully merged into the v9 branch.

Fixes: https://github.com/debois/elm-mdl/issues/61